### PR TITLE
Upgrade 12.04-based containers to 14.04

### DIFF
--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -11,10 +11,6 @@ RUN apt-get update && \
 
 COPY xargo.sh /
 RUN bash /xargo.sh
-
-COPY cmake.sh /
-RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
 
 COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -11,10 +11,6 @@ RUN apt-get update && \
 
 COPY xargo.sh /
 RUN bash /xargo.sh
-
-COPY cmake.sh /
-RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
 
 COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -11,10 +11,6 @@ RUN apt-get update && \
 
 COPY xargo.sh /
 RUN bash /xargo.sh
-
-COPY cmake.sh /
-RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
 
 COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Aims to fix #149 for `armv7-unknown-linux-gnueabihf`, `i686-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` containers, by upgrading them to Ubuntu 14.04, where multiarch is properly supported.