### PR TITLE
Upgrade CMake to at least 3.5.1 on all images

### DIFF
--- a/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+COPY cmake.sh /
+RUN apt-get purge --auto-remove -y cmake && \
+    bash /cmake.sh 3.5.1
+
 COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-aarch64-linux-gnu \

--- a/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+COPY cmake.sh /
+RUN apt-get purge --auto-remove -y cmake && \
+    bash /cmake.sh 3.5.1
+
 COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-arm-linux-gnueabi \

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -14,7 +14,7 @@ RUN bash /xargo.sh
 
 COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
+    bash /cmake.sh 3.5.1
 
 COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \

--- a/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/docker/i586-unknown-linux-gnu/Dockerfile
@@ -12,10 +12,6 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY cmake.sh /
-RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
-
 COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-multilib && \

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -14,7 +14,7 @@ RUN bash /xargo.sh
 
 COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
+    bash /cmake.sh 3.5.1
 
 COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \

--- a/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+COPY cmake.sh /
+RUN apt-get purge --auto-remove -y cmake && \
+    bash /cmake.sh 3.5.1
+
 COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-powerpc-linux-gnu \

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -14,7 +14,7 @@ RUN bash /xargo.sh
 
 COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
-    bash /cmake.sh 2.8.11
+    bash /cmake.sh 3.5.1
 
 COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
I'm currently writing Rust bindings for a C project which only supports CMake >= 3.1. I've choosen 3.5.1 as that is the version which is available on Ubuntu 16.04.