### PR TITLE
Add  qemu-system support for more targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - env: TARGET=arm-unknown-linux-gnueabi       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=armv7-unknown-linux-gnueabihf   CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=i586-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
-    - env: TARGET=i686-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=i686-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="native qemu-user qemu-system"
     - env: TARGET=mips-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=mips64-unknown-linux-gnuabi64   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-system"
-    - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-system"
+    - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-system"
     - env: TARGET=x86_64-unknown-linux-gnu        CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1 DEPLOY=1 RUNNERS="native qemu-user qemu-system"
 
     # Linux musl

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system" CROSS_DEBUG=1
     - env: TARGET=arm-unknown-linux-gnueabi       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
-    - env: TARGET=armv7-unknown-linux-gnueabihf   CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=armv7-unknown-linux-gnueabihf   CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=i586-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=i686-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=mips-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
     - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1
-    - env: TARGET=x86_64-unknown-linux-gnu        CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1 DEPLOY=1
+    - env: TARGET=x86_64-unknown-linux-gnu        CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1 DEPLOY=1 RUNNERS="native qemu-user qemu-system"
 
     # Linux musl
     - env: TARGET=aarch64-unknown-linux-musl                    STD=1 OPENSSL=0.5.5  RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ matrix:
     - env: TARGET=armv7-unknown-linux-gnueabihf   CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=i586-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=i686-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="native qemu-user qemu-system"
-    - env: TARGET=mips-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=mips-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
+    - env: TARGET=mipsel-unknown-linux-gnu        CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=mips64-unknown-linux-gnuabi64   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
-    - env: TARGET=mipsel-unknown-linux-gnu        CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: TARGET=mips64-unknown-linux-gnuabi64   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
-    - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
+    - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
     - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
-    - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
+    - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
     - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1
     - env: TARGET=x86_64-unknown-linux-gnu        CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1 DEPLOY=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - env: TARGET=mips-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=mipsel-unknown-linux-gnu        CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=mips64-unknown-linux-gnuabi64   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
-    - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
+    - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
     - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
-    - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
-    - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1
+    - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-system"
+    - env: TARGET=sparc64-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-system"
     - env: TARGET=x86_64-unknown-linux-gnu        CPP=1 DYLIB=1       OPENSSL=0.5.5  RUN=1 DEPLOY=1 RUNNERS="native qemu-user qemu-system"
 
     # Linux musl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - env: TARGET=mipsel-unknown-linux-gnu        CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=mips64-unknown-linux-gnuabi64   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
-    - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=powerpc-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc64-unknown-linux-gnu     CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=powerpc64le-unknown-linux-gnu   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=s390x-unknown-linux-gnu         CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -16,15 +16,26 @@ COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
     bash /cmake.sh 3.5.1
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-arm-linux-gnueabihf \
-    libc6-dev-armhf-cross && \
-    bash /openssl.sh linux-armv4 arm-linux-gnueabihf- && \
-    bash /qemu.sh arm
+    libc6-dev-armhf-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux-armv4 arm-linux-gnueabihf-
+
+COPY qemu.sh /
+RUN bash /qemu.sh arm linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh armv7
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER="/linux-runner armv7" \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -16,11 +16,24 @@ COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
     bash /cmake.sh 3.5.1
 
-COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \
-    g++-multilib && \
-    bash /openssl.sh linux-elf "" -m32
+    g++-multilib
 
-ENV OPENSSL_DIR=/openssl \
+COPY openssl.sh /
+RUN bash /openssl.sh linux-elf "" -m32
+
+COPY qemu.sh /
+RUN bash /qemu.sh i386 linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh i686
+
+COPY linux-runner /
+
+ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner i686" \
+    OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -25,6 +25,10 @@ main() {
         mips64el)
             kernel=$kversion-5kc-malta
             ;;
+        powerpc64le)
+            arch=ppc64el
+            kernel=$kversion-powerpc64le
+            ;;
         *)
             echo "Invalid arch: $arch"
             exit 1

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -133,7 +133,7 @@ main() {
 
     # kernel
     if [ "$arch" = "sparc64" ]; then
-        # the but fails if the kernel is compressed
+        # boot fails if the kernel is compressed
         zcat $root/boot/vmlinu* > kernel
     else
         cp $root/boot/vmlinu* kernel

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -11,6 +11,10 @@ main() {
             arch=arm64
             kernel=$kversion-arm64
             ;;
+        armv7)
+            arch=armhf
+            kernel=4.9.0-4-armmp
+            ;;
         *)
             echo "Invalid arch: $arch"
             exit 1

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -43,7 +43,7 @@ main() {
         powerpc64)
             # there is no stable port
             arch=ppc64
-            kernel=4.14.0-1-powerpc64
+            kernel=4.15.0-2-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies
@@ -59,7 +59,7 @@ main() {
             ;;
         sparc64)
             # there is no stable port
-            kernel=4.14.0-3-sparc64
+            kernel=4.15.0-1-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies
@@ -106,6 +106,7 @@ main() {
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 7638D0442B90D010
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 8BC3A7D46F930576 # ports
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com CBF8D6FD518E17E1
+    apt-key adv --recv-key --keyserver keyserver.ubuntu.com 06AED62430CB581C
     apt-get update
 
     mkdir -p -m 777 /qemu/$arch

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -8,6 +8,8 @@ main() {
     local debsource="deb http://http.debian.net/debian/ stretch main"
     debsource="$debsource\ndeb http://security.debian.org/ stretch/updates main"
 
+    local dropbear="dropbear-bin"
+
     # select debian arch and kernel version
     case $arch in
         aarch64)
@@ -27,6 +29,14 @@ main() {
             ;;
         mips64el)
             kernel=$kversion-5kc-malta
+            ;;
+        powerpc)
+            # there is no stretch powerpc port, so we use jessie
+            # use a more recent kernel from backports
+            kernel=4.9.0-0.bpo.4-powerpc
+            debsource="deb http://http.debian.net/debian/ jessie main"
+            debsource="$debsource\ndeb http://http.debian.net/debian/ jessie-backports main"
+            dropbear="dropbear"
             ;;
         powerpc64)
             arch=ppc64
@@ -90,6 +100,7 @@ main() {
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 8B48AD6246925553
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 7638D0442B90D010
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 8BC3A7D46F930576 # ports
+    apt-key adv --recv-key --keyserver keyserver.ubuntu.com CBF8D6FD518E17E1
     apt-get update
 
     mkdir -p -m 777 /qemu/$arch
@@ -97,10 +108,10 @@ main() {
     apt-get -d --no-install-recommends download \
         $deps \
         busybox:$arch \
-        dropbear-bin:$arch \
+        $dropbear:$arch \
         libc6:$arch \
         libgcc1:$arch \
-        libssl1.1:$arch \
+        libssl1.0:$arch \
         libstdc++6:$arch \
         linux-image-$kernel:$arch \
         ncurses-base \

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -59,7 +59,7 @@ main() {
             ;;
         sparc64)
             # there is no stable port
-            kernel=4.14.0-1-sparc64
+            kernel=4.14.0-3-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -19,6 +19,9 @@ main() {
             arch=i386
             kernel=$kversion-686
             ;;
+        mips|mipsel)
+            kernel=$kversion-4kc-malta
+            ;;
         *)
             echo "Invalid arch: $arch"
             exit 1

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -43,7 +43,7 @@ main() {
         powerpc64)
             # there is no stable port
             arch=ppc64
-            kernel=4.15.0-2-powerpc64
+            kernel=4.18.0-2-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies
@@ -59,7 +59,7 @@ main() {
             ;;
         sparc64)
             # there is no stable port
-            kernel=4.15.0-1-sparc64
+            kernel=4.18.0-2-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies
@@ -142,12 +142,14 @@ main() {
     # initrd
     mkdir -p $root/modules
     cp \
+        $root/lib/modules/*/kernel/drivers/net/net_failover.ko \
         $root/lib/modules/*/kernel/drivers/net/virtio_net.ko \
         $root/lib/modules/*/kernel/drivers/virtio/* \
         $root/lib/modules/*/kernel/fs/9p/9p.ko \
         $root/lib/modules/*/kernel/fs/fscache/fscache.ko \
         $root/lib/modules/*/kernel/net/9p/9pnet.ko \
         $root/lib/modules/*/kernel/net/9p/9pnet_virtio.ko \
+        $root/lib/modules/*/kernel/net/core/failover.ko \
         $root/modules || true # some file may not exist
     rm -rf $root/boot
     rm -rf $root/lib/modules
@@ -205,6 +207,8 @@ mkdir /dev/pts
 mount -t devpts none /dev/pts/
 
 # some archs does not have virtio modules
+insmod /modules/failover.ko || true
+insmod /modules/net_failover.ko || true
 insmod /modules/virtio.ko || true
 insmod /modules/virtio_ring.ko || true
 insmod /modules/virtio_mmio.ko || true

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -214,7 +214,7 @@ ifconfig eth0 10.0.2.15
 route add default gw 10.0.2.2 eth0
 
 mkdir /target
-mount -t 9p -o trans=virtio target /target -oversion=9p2000.L || true
+mount -t 9p -o trans=virtio target /target -oversion=9p2000.u || true
 
 exec dropbear -F -E -B
 EOF

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -29,6 +29,10 @@ main() {
             arch=ppc64el
             kernel=$kversion-powerpc64le
             ;;
+        s390x)
+            arch=s390x
+            kernel=$kversion-s390x
+            ;;
         *)
             echo "Invalid arch: $arch"
             exit 1

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -13,7 +13,11 @@ main() {
             ;;
         armv7)
             arch=armhf
-            kernel=4.9.0-4-armmp
+            kernel=$kversion-armmp
+            ;;
+        i686)
+            arch=i386
+            kernel=$kversion-686
             ;;
         *)
             echo "Invalid arch: $arch"

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -9,6 +9,7 @@ main() {
     debsource="$debsource\ndeb http://security.debian.org/ stretch/updates main"
 
     local dropbear="dropbear-bin"
+    local libssl="libssl1.0.2"
 
     # select debian arch and kernel version
     case $arch in
@@ -37,8 +38,10 @@ main() {
             debsource="deb http://http.debian.net/debian/ jessie main"
             debsource="$debsource\ndeb http://http.debian.net/debian/ jessie-backports main"
             dropbear="dropbear"
+            libssl="libssl1.0.0"
             ;;
         powerpc64)
+            # there is no stable port
             arch=ppc64
             kernel=4.14.0-1-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
@@ -55,9 +58,11 @@ main() {
             kernel=$kversion-s390x
             ;;
         sparc64)
+            # there is no stable port
             kernel=4.14.0-1-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
+            # sid version of dropbear requeries this depencendies
             deps="libtommath1:sparc64 libtomcrypt1:sparc64 libgmp10:sparc64"
             ;;
         x86_64)
@@ -111,7 +116,7 @@ main() {
         $dropbear:$arch \
         libc6:$arch \
         libgcc1:$arch \
-        libssl1.0:$arch \
+        $libssl:$arch \
         libstdc++6:$arch \
         linux-image-$kernel:$arch \
         ncurses-base \

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -44,6 +44,12 @@ main() {
             arch=s390x
             kernel=$kversion-s390x
             ;;
+        sparc64)
+            kernel=4.14.0-1-sparc64
+            debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
+            debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
+            deps="libtommath1:sparc64 libtomcrypt1:sparc64 libgmp10:sparc64"
+            ;;
         x86_64)
             arch=amd64
             kernel=$kversion-amd64
@@ -109,7 +115,12 @@ main() {
     done
 
     # kernel
-    cp $root/boot/vmlinu* kernel
+    if [ "$arch" = "sparc64" ]; then
+        # the but fails if the kernel is compressed
+        zcat $root/boot/vmlinu* > kernel
+    else
+        cp $root/boot/vmlinu* kernel
+    fi
 
     # initrd
     mkdir -p $root/modules

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -22,6 +22,9 @@ main() {
         mips|mipsel)
             kernel=$kversion-4kc-malta
             ;;
+        mips64el)
+            kernel=$kversion-5kc-malta
+            ;;
         *)
             echo "Invalid arch: $arch"
             exit 1

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -125,7 +125,7 @@ main() {
 
     # Install packages
     root=root-$arch
-    mkdir -p $root/{bin,etc/dropbear,root,sys,dev,proc,sbin,usr/{bin,sbin},var/log}
+    mkdir -p $root/{bin,etc/dropbear,root,sys,dev,proc,sbin,tmp,usr/{bin,sbin},var/log}
     for deb in $arch/*deb; do
         dpkg -x $deb $root/
     done

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -34,7 +34,7 @@ main() {
         powerpc)
             # there is no stretch powerpc port, so we use jessie
             # use a more recent kernel from backports
-            kernel=4.9.0-0.bpo.4-powerpc
+            kernel=4.9.0-0.bpo.6-powerpc
             debsource="deb http://http.debian.net/debian/ jessie main"
             debsource="$debsource\ndeb http://http.debian.net/debian/ jessie-backports main"
             dropbear="dropbear"

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -33,6 +33,10 @@ main() {
             arch=s390x
             kernel=$kversion-s390x
             ;;
+        x86_64)
+            arch=amd64
+            kernel=$kversion-amd64
+            ;;
         *)
             echo "Invalid arch: $arch"
             exit 1
@@ -65,6 +69,7 @@ main() {
         cp /etc/dpkg/dpkg.cfg.d/multiarch /etc/dpkg/dpkg.cfg.d/multiarch.bak
     fi
     dpkg --add-architecture $arch || echo "foreign-architecture $arch" > /etc/dpkg/dpkg.cfg.d/multiarch
+
     # Add debian keys
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com EF0F382A1A7B6500
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 9D6D8F6BC857C906
@@ -79,7 +84,7 @@ main() {
         dropbear-bin:$arch \
         libc6:$arch \
         libgcc1:$arch \
-        libssl1*:$arch \
+        libssl1.1:$arch \
         libstdc++6:$arch \
         linux-image-$kernel:$arch \
         ncurses-base \

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -22,6 +22,13 @@ case "$arch" in
     i686)
         qarch="i386"
         ;;
+    powerpc64le)
+        if [ "$CROSS_RUNNER" = "qemu-user" ]; then
+            qarch="ppc64le"
+        else
+            qarch="ppc64"
+        fi
+        ;;
 esac
 
 case "$CROSS_RUNNER" in
@@ -75,6 +82,11 @@ case "$arch" in
         # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
         opt="-append nokaslr -cpu MIPS64R2-generic"
         n=1
+        driver9p="virtio-9p-pci"
+        drivernet="virtio-net-pci"
+        ;;
+    powerpc64le)
+        opt="-append console=hvc0 --nodefaults -serial stdio"
         driver9p="virtio-9p-pci"
         drivernet="virtio-net-pci"
         ;;

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -111,7 +111,7 @@ esac
 
     echo Booting QEMU virtual machine with $n cpus...
 
-    QEMU_CMD="qemu-system-$arch \
+    QEMU_CMD="qemu-system-$qarch \
         -m $memory \
         -smp $n \
         -nographic \

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -42,6 +42,10 @@ case "$arch" in
     aarch64)
         opt="-machine virt -cpu cortex-a57"
         ;;
+    armv7)
+        opt="-machine virt"
+        arch="arm"
+        ;;
 esac
 
 (

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -22,6 +22,9 @@ case "$arch" in
     i686)
         qarch="i386"
         ;;
+    powerpc64)
+        qarch="ppc64"
+        ;;
     powerpc64le)
         if [ "$CROSS_RUNNER" = "qemu-user" ]; then
             qarch="ppc64le"
@@ -80,7 +83,7 @@ case "$arch" in
         opt="-append nokaslr -cpu MIPS64R2-generic"
         n=1
         ;;
-    powerpc64le)
+    powerpc64|powerpc64le)
         opt="-append console=hvc0 --nodefaults -serial stdio"
         ;;
     s390x)

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -13,6 +13,17 @@ fi
 arch=$1
 shift
 
+# select qemu arch
+qarch=$arch
+case "$arch" in
+    armv7)
+        qarch="arm"
+        ;;
+    i686)
+        qarch="i386"
+        ;;
+esac
+
 case "$CROSS_RUNNER" in
     native)
         exec "${@}"
@@ -44,7 +55,11 @@ case "$arch" in
         ;;
     armv7)
         opt="-machine virt"
-        arch="arm"
+        ;;
+    i686)
+        opt="-append console=ttyS0"
+        driver9p="virtio-9p-pci"
+        drivernet="virtio-net-pci"
         ;;
 esac
 

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -89,6 +89,9 @@ case "$arch" in
     s390x)
         n=1
         ;;
+    sparc64)
+        n=1
+        ;;
     x86_64)
         opt="-append console=ttyS0"
         ;;
@@ -147,11 +150,12 @@ dir=$(dirname "$1")
 shift
 
 ssh="dbclient -t -p 10022 -y -y root@localhost"
-# In some system, programs in 9p file system fails to execute (Socket operation on non-socket)
+# In some system, programs in 9p file system fails to execute
+# (mips: Socket operation on non-socket, sparc64: Level 2 not synchronized)
 # The workaround is to copy the file to the ramdisk fs and then execute it.
 # See https://github.com/chaos/diod/issues/35
 case "$arch" in
-    mips|mipsel|mips64el)
+    mips|mipsel|mips64el|sparc64)
         $ssh mkdir -p "/tmp/$dir" ";" cp "$prog" "/tmp/$prog" ";" "/tmp/$prog" "${@}"
         R=$!
         $ssh rm -f "/tmp/$prog"

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -72,7 +72,6 @@ case "$arch" in
         # avoid kernel error
         # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
         opt="-append nokaslr"
-        # fails if > 1
         n=1
         driver9p="virtio-9p-pci"
         drivernet="virtio-net-pci"
@@ -89,6 +88,11 @@ case "$arch" in
         opt="-append console=hvc0 --nodefaults -serial stdio"
         driver9p="virtio-9p-pci"
         drivernet="virtio-net-pci"
+        ;;
+    s390x)
+        n=1
+        driver9p="virtio-9p-ccw"
+        drivernet="virtio-net-ccw"
         ;;
 esac
 

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -22,6 +22,9 @@ case "$arch" in
     i686)
         qarch="i386"
         ;;
+    powerpc)
+        qarch="ppc"
+        ;;
     powerpc64)
         qarch="ppc64"
         ;;
@@ -81,6 +84,10 @@ case "$arch" in
         # avoid kernel error
         # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
         opt="-append nokaslr -cpu MIPS64R2-generic"
+        n=1
+        ;;
+    powerpc)
+        opt="-append console=ttyPZ0"
         n=1
         ;;
     powerpc64|powerpc64le)

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -65,11 +65,11 @@ drivernet="virtio-net-pci"
 case "$arch" in
     aarch64)
         opt="-machine virt -cpu cortex-a57"
-        driver9p="virtio-9p-device"
-        drivernet="virtio-net-device"
         ;;
     armv7)
         opt="-machine virt"
+        driver9p="virtio-9p-device"
+        drivernet="virtio-net-device"
         ;;
     i686)
         opt="-append console=ttyS0"

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -42,7 +42,7 @@ case "$CROSS_RUNNER" in
         exec "${@}"
         ;;
     qemu-user | "")
-        exec qemu-$arch "${@}"
+        exec qemu-$qarch "${@}"
         ;;
     qemu-system)
         true

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -70,6 +70,14 @@ case "$arch" in
         driver9p="virtio-9p-pci"
         drivernet="virtio-net-pci"
         ;;
+    mips64el)
+        # avoid kernel error
+        # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
+        opt="-append nokaslr -cpu MIPS64R2-generic"
+        n=1
+        driver9p="virtio-9p-pci"
+        drivernet="virtio-net-pci"
+        ;;
 esac
 
 (
@@ -125,11 +133,11 @@ dir=$(dirname "$1")
 shift
 
 ssh="dbclient -t -p 10022 -y -y root@localhost"
-# In some system, programs in 9p file system fails to execute.
+# In some system, programs in 9p file system fails to execute (Socket operation on non-socket)
 # The workaround is to copy the file to the ramdisk fs and then execute it.
 # See https://github.com/chaos/diod/issues/35
 case "$arch" in
-    mips|mipsel)
+    mips|mipsel|mips64el)
         $ssh mkdir -p "/tmp/$dir" ";" cp "$prog" "/tmp/$prog" ";" "/tmp/$prog" "${@}"
         R=$!
         $ssh rm -f "/tmp/$prog"

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -52,47 +52,42 @@ esac
 n=$(nproc)
 n=$(( n > 8 ? 8 : n ))
 memory=1G
-driver9p="virtio-9p-device"
-drivernet="virtio-net-device"
+driver9p="virtio-9p-pci"
+drivernet="virtio-net-pci"
 
 # select qemu parameters
 case "$arch" in
     aarch64)
         opt="-machine virt -cpu cortex-a57"
+        driver9p="virtio-9p-device"
+        drivernet="virtio-net-device"
         ;;
     armv7)
         opt="-machine virt"
         ;;
     i686)
         opt="-append console=ttyS0"
-        driver9p="virtio-9p-pci"
-        drivernet="virtio-net-pci"
         ;;
     mips|mipsel)
         # avoid kernel error
         # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
         opt="-append nokaslr"
         n=1
-        driver9p="virtio-9p-pci"
-        drivernet="virtio-net-pci"
         ;;
     mips64el)
         # avoid kernel error
         # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
         opt="-append nokaslr -cpu MIPS64R2-generic"
         n=1
-        driver9p="virtio-9p-pci"
-        drivernet="virtio-net-pci"
         ;;
     powerpc64le)
         opt="-append console=hvc0 --nodefaults -serial stdio"
-        driver9p="virtio-9p-pci"
-        drivernet="virtio-net-pci"
         ;;
     s390x)
         n=1
-        driver9p="virtio-9p-ccw"
-        drivernet="virtio-net-ccw"
+        ;;
+    x86_64)
+        opt="-append console=ttyS0"
         ;;
 esac
 

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -54,9 +54,7 @@ case "$CROSS_RUNNER" in
         ;;
 esac
 
-# 8 is the max number of cpu supported by qemu-aarch64
 n=$(nproc)
-n=$(( n > 8 ? 8 : n ))
 memory=1G
 driver9p="virtio-9p-pci"
 drivernet="virtio-net-pci"
@@ -64,6 +62,8 @@ drivernet="virtio-net-pci"
 # select qemu parameters
 case "$arch" in
     aarch64)
+        # 8 is the max number of cpu supported by qemu-aarch64
+        n=$(( n > 8 ? 8 : n ))
         opt="-machine virt -cpu cortex-a57"
         ;;
     armv7)

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -150,7 +150,7 @@ esac
         fi
     fi
 
-    echo Booted in $(dbclient -K 1 -p 10022 -y -y root@localhost "cut -d' ' -f1 /proc/uptime") seconds
+    echo Booted in $SECONDS seconds
 
 ) 200>$LOCK
 

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -61,6 +61,15 @@ case "$arch" in
         driver9p="virtio-9p-pci"
         drivernet="virtio-net-pci"
         ;;
+    mips|mipsel)
+        # avoid kernel error
+        # https://blahcat.github.io/2017/07/14/building-a-debian-stretch-qemu-image-for-mipsel/
+        opt="-append nokaslr"
+        # fails if > 1
+        n=1
+        driver9p="virtio-9p-pci"
+        drivernet="virtio-net-pci"
+        ;;
 esac
 
 (
@@ -111,9 +120,22 @@ esac
 
 ) 200>$LOCK
 
-dbclient \
-    -t \
-    -p 10022 \
-    -y -y \
-    root@localhost \
-    "${@}"
+prog="$1"
+dir=$(dirname "$1")
+shift
+
+ssh="dbclient -t -p 10022 -y -y root@localhost"
+# In some system, programs in 9p file system fails to execute.
+# The workaround is to copy the file to the ramdisk fs and then execute it.
+# See https://github.com/chaos/diod/issues/35
+case "$arch" in
+    mips|mipsel)
+        $ssh mkdir -p "/tmp/$dir" ";" cp "$prog" "/tmp/$prog" ";" "/tmp/$prog" "${@}"
+        R=$!
+        $ssh rm -f "/tmp/$prog"
+        exit $R
+        ;;
+    *)
+        exec $ssh "$prog" "${@}"
+        ;;
+esac

--- a/docker/linux-runner
+++ b/docker/linux-runner
@@ -95,6 +95,8 @@ case "$arch" in
         ;;
     s390x)
         n=1
+        driver9p="virtio-9p-ccw"
+        drivernet="virtio-net-ccw"
         ;;
     sparc64)
         n=1
@@ -152,23 +154,4 @@ esac
 
 ) 200>$LOCK
 
-prog="$1"
-dir=$(dirname "$1")
-shift
-
-ssh="dbclient -t -p 10022 -y -y root@localhost"
-# In some system, programs in 9p file system fails to execute
-# (mips: Socket operation on non-socket, sparc64: Level 2 not synchronized)
-# The workaround is to copy the file to the ramdisk fs and then execute it.
-# See https://github.com/chaos/diod/issues/35
-case "$arch" in
-    mips|mipsel|mips64el|sparc64)
-        $ssh mkdir -p "/tmp/$dir" ";" cp "$prog" "/tmp/$prog" ";" "/tmp/$prog" "${@}"
-        R=$!
-        $ssh rm -f "/tmp/$prog"
-        exit $R
-        ;;
-    *)
-        exec $ssh "$prog" "${@}"
-        ;;
-esac
+exec dbclient -t -p 10022 -y -y root@localhost "${@}"

--- a/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/docker/mips-unknown-linux-gnu/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-mips-linux-gnu \
-    libc6-dev-mips-cross && \
-    bash /openssl.sh linux-mips32 mips-linux-gnu- && \
-    bash /qemu.sh mips
+    libc6-dev-mips-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux-mips32 mips-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh mips linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh mips
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER=qemu-mips \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner mips" \
     CC_mips_unknown_linux_gnu=mips-linux-gnu-gcc \
     CXX_mips_unknown_linux_gnu=mips-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-mips64el-linux-gnuabi64 \
-    libc6-dev-mips64el-cross && \
-    bash /openssl.sh linux64-mips64 mips64el-linux-gnuabi64- && \
-    bash /qemu.sh mips64el
+    libc6-dev-mips64el-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux64-mips64 mips64el-linux-gnuabi64-
+
+COPY qemu.sh /
+RUN bash /qemu.sh mips64el linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh mips64el
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-gcc \
-    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64el \
+    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER="/linux-runner mips64el" \
     CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc \
     CXX_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-mipsel-linux-gnu \
-    libc6-dev-mipsel-cross && \
-    bash /openssl.sh linux-mips32 mipsel-linux-gnu- && \
-    bash /qemu.sh mipsel
+    libc6-dev-mipsel-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux-mips32 mipsel-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh mipsel linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh mipsel
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER=qemu-mipsel \
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner mipsel" \
     CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc \
     CXX_mipsel_unknown_linux_gnu=mipsel-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -16,15 +16,26 @@ COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
     bash /cmake.sh 3.5.1
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-powerpc-linux-gnu \
-    libc6-dev-powerpc-cross && \
-    bash /openssl.sh linux-ppc powerpc-linux-gnu- && \
-    bash /qemu.sh ppc
+    libc6-dev-powerpc-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux-ppc powerpc-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh ppc linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh powerpc
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
-    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc \
+    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner powerpc" \
     CC_powerpc_unknown_linux_gnu=powerpc-linux-gnu-gcc \
     CXX_powerpc_unknown_linux_gnu=powerpc-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-powerpc64-linux-gnu \
-    libc6-dev-ppc64-cross && \
-    bash /openssl.sh linux-ppc64 powerpc64-linux-gnu- && \
-    bash /qemu.sh ppc64
+    libc6-dev-ppc64-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux-ppc64 powerpc64-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh ppc64 linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh powerpc64
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
-    CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64 \
+    CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner powerpc64" \
     CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
     CXX_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-powerpc64le-linux-gnu \
-    libc6-dev-ppc64el-cross && \
-    bash /openssl.sh linux-ppc64le powerpc64le-linux-gnu- && \
-    bash /qemu.sh ppc64le
+    libc6-dev-ppc64el-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux-ppc64le powerpc64le-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh ppc64le linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh powerpc64le
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
-    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64le \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner powerpc64le" \
     CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
     CXX_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -126,7 +126,11 @@ EOF
    local virtfs=""
    case "$softmmu" in
       softmmu)
-         targets="$targets,$arch-softmmu"
+         if [ "$arch" = "ppc64le" ]; then
+            targets="$targets,ppc64-softmmu"
+         else
+            targets="$targets,$arch-softmmu"
+         fi
          virtfs="--enable-virtfs"
          ;;
       "")

--- a/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-s390x-linux-gnu \
-    libc6-dev-s390x-cross && \
-    bash /openssl.sh linux64-s390x s390x-linux-gnu- && \
-    bash /qemu.sh s390x
+    libc6-dev-s390x-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux64-s390x s390x-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh s390x linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh s390x
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
-    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER=qemu-s390x \
+    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner s390x" \
     CC_s390x_unknown_linux_gnu=s390x-linux-gnu-gcc \
     CXX_s390x_unknown_linux_gnu=s390x-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -12,15 +12,26 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
-COPY openssl.sh qemu.sh /
 RUN apt-get install -y --no-install-recommends \
     g++-sparc64-linux-gnu \
-    libc6-dev-sparc64-cross && \
-    bash /openssl.sh linux64-sparcv9 sparc64-linux-gnu- && \
-    bash /qemu.sh sparc64
+    libc6-dev-sparc64-cross
+
+COPY openssl.sh /
+RUN bash /openssl.sh linux64-sparcv9 sparc64-linux-gnu-
+
+COPY qemu.sh /
+RUN bash /qemu.sh sparc64 linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh sparc64
+
+COPY linux-runner /
 
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \
-    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-sparc64 \
+    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner sparc64" \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
     CXX_sparc64_unknown_linux_gnu=sparc64-linux-gnu-g++ \
     OPENSSL_DIR=/openssl \

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -16,12 +16,26 @@ COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
     bash /cmake.sh 3.5.1
 
-COPY openssl.sh /
 RUN apt-get install -y --no-install-recommends \
     g++ \
-    zlib1g-dev && \
-    bash /openssl.sh linux-x86_64
+    zlib1g-dev
 
-ENV OPENSSL_DIR=/openssl \
+COPY openssl.sh /
+RUN bash /openssl.sh linux-x86_64
+
+COPY qemu.sh /
+RUN bash /qemu.sh x86_64 linux softmmu
+
+COPY dropbear.sh /
+RUN bash /dropbear.sh
+
+COPY linux-image.sh /
+RUN bash /linux-image.sh x86_64
+
+COPY linux-runner /
+
+
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner x86_64" \
+    OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -34,7 +34,6 @@ RUN bash /linux-image.sh x86_64
 
 COPY linux-runner /
 
-
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner x86_64" \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \


### PR DESCRIPTION
Add qemu-system support for the following targets:

- aarch64-unknown-linux-gnu
- armv7-unknown-linux-gnueabihf
- i686-unknown-linux-gnu
- mips-unknown-linux-gnu
- mipsel-unknown-linux-gnu
- mips64el-unknown-linux-gnuabi64
- powerpc-unknown-linux-gnu
- powerpc64-unknown-linux-gnu
- powerpc64le-unknown-linux-gnu
- s390x-unknown-linux-gnu
- sparc64-unknown-linux-gnu
- x86_64-unknown-linux-gnu

Running `cross test` fails for `s390x-unknown-linux-gnu` and `sparc64-unknown-linux-gnu`, but `cargo run` works. This maybe be a bug in qemu or rustc.

Debian does not have a port for `mips64-unknown-linux-gnuabi64`. Support for arm targets can be add later, but I think a custom kernel will be need.

musl targets can get qemu-system support latter.