### PR TITLE
Don't allocate a pseudo-TTY

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -61,7 +61,7 @@ pub fn register(target: &Target, verbose: bool) -> Result<()> {
     docker_command("run")
         .arg("--privileged")
         .arg("--rm")
-        .arg("-it")
+        .arg("-i")
         .arg("ubuntu:16.04")
         .args(&["sh", "-c", cmd])
         .run(verbose)
@@ -139,7 +139,7 @@ pub fn run(target: &Target,
         .args(&["-v", &format!("{}:/rust:ro", rustc::sysroot(verbose)?.display())])
         .args(&["-v", &format!("{}:/target", target_dir.display())])
         .args(&["-w", "/project"])
-        .args(&["-it", &image(toml, target)?])
+        .args(&["-i", &image(toml, target)?])
         .args(&["sh", "-c", &format!("PATH=$PATH:/rust/bin {:?}", cmd)])
         .run_and_get_status(verbose)
 }


### PR DESCRIPTION
This fixes issue #52 as far as I can tell.

Since documentation on the Docker `-t` flag is rather sparse, I am not sure if this has any negative implications on existing usage of cross.

From my arguably limited tests, I have [confirmed](https://gist.github.com/pitkley/c581f612225688937cc8b7f3a7deff9a) that `echo hello | cross run` works. Furthermore, this enables me to run `cross build` in a Gitlab CI job, which otherwise also failed with the error mentioned in #52: `the input device is not a TTY`.