### PR TITLE
Update NetBSD patch locations

### DIFF
--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -40,8 +40,8 @@ main() {
     cd gcc
     ./contrib/download_prerequisites
     local patches=(
-        ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
-        ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__configure__char.cc
+        ftp://ftp.netbsd.org/pub/pkgsrc/stable/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
+        ftp://ftp.netbsd.org/pub/pkgsrc/stable/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__configure__char.cc
     )
 
     local patch


### PR DESCRIPTION
The directory `/pub/pkgsrc/pkgsrc-2016Q4/` doesn't exist anymore on the
`ftp.netbsd.org` FTP server. Noticed this while customizing the image and building it
from scratch.

Instead there are two other directories, `/pub/pkgsrc/pkgsrc-2017Q4/` and
`/pub/pkgsrc/stable`, where the patch files seem to be located.

There's a good chance these URIs will need to be updated again next year
if we use the `2017Q4` ones, so instead use the `stable` directory as a
source location.

---

Let me know if instead the `2017Q4` directory is preferred. Both seem to provide the same patch files.