### PR TITLE
Replace gcc's download_prerequisites with Ubuntu packages

### DIFF
--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -12,6 +12,10 @@ main() {
         ca-certificates
         curl
         g++
+        libgmp-dev
+        libisl-dev
+        libmpc-dev
+        libmpfr-dev
         make
         patch
         wget
@@ -40,7 +44,6 @@ main() {
     pushd $td
 
     cd gcc
-    ./contrib/download_prerequisites
     patch -p0 <<'EOF'
 --- libatomic/configure.tgt.orig	2015-07-09 16:08:55 UTC
 +++ libatomic/configure.tgt

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -12,6 +12,10 @@ main() {
         ca-certificates
         curl
         g++
+        libgmp-dev
+        libisl-dev
+        libmpc-dev
+        libmpfr-dev
         make
         wget
         xz-utils
@@ -37,10 +41,6 @@ main() {
         tar -C $td/gcc --strip-components=1 -xj
 
     pushd $td
-
-    cd gcc
-    ./contrib/download_prerequisites
-    cd ..
 
     local bsd_arch=
     case $arch in

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -10,6 +10,10 @@ main() {
         ca-certificates
         curl
         g++
+        libgmp-dev
+        libisl-dev
+        libmpc-dev
+        libmpfr-dev
         make
         patch
         wget
@@ -38,7 +42,6 @@ main() {
     pushd $td
 
     cd gcc
-    ./contrib/download_prerequisites
     local patches=(
         ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
         ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__configure__char.cc

--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -12,6 +12,10 @@ main() {
         ca-certificates
         curl
         g++
+        libgmp-dev
+        libisl-dev
+        libmpc-dev
+        libmpfr-dev
         make
         software-properties-common
         wget
@@ -38,10 +42,6 @@ main() {
         tar -C $td/gcc --strip-components=1 -xj
 
     pushd $td
-
-    cd gcc
-    ./contrib/download_prerequisites
-    cd ..
 
     local apt_arch=
     local lib_arch=


### PR DESCRIPTION
Travis CI has problems downloading from GNU's FTP servers,
so use the appropriate Ubuntu packages to not cause timeouts.