### PR TITLE
Add --platform flag to docker command when available

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -36,14 +36,26 @@ lazy_static! {
         VersionReq::parse(">= 1.24")
             .expect("Unable to parse version requirements")
     };
+
+    /// Version requirements for user namespace.
+    ///
+    /// # Panics
+    /// Panics if the parsing fails
+    static ref PLATFORM_REQUIREMENT: VersionReq = {
+        VersionReq::parse(">= 1.32")
+            .expect("Unable to parse version requirements")
+    };
 }
 
-/// Add the `userns` flag, if needed
+/// Add the `userns` and `platform` flags, if needed
 pub fn docker_command(subcommand: &str) -> Command {
     let mut docker = Command::new("docker");
     docker.arg(subcommand);
     if USERNS_REQUIREMENT.matches(&DOCKER_VERSION) {
         docker.args(&["--userns", "host"]);
+    }
+    if PLATFORM_REQUIREMENT.matches(&DOCKER_VERSION) {
+        docker.args(&["--platform", "linux"]);
     }
     docker
 }


### PR DESCRIPTION
This allows using cross with Docker on Windows using `--platform linux`.

Sadly, it does not allow Docker on Windows on Windows Subsystem for Linux to work.

That would require translating the paths in the Docker command, per this error:

```
$ cross test --target mips64-unknown-linux-gnuabi64
Unable to find image 'japaric/mips64-unknown-linux-gnuabi64:latest' locally
latest: Pulling from japaric/mips64-unknown-linux-gnuabi64
8d51e945c435: Pull complete
d8d21cdaac84: Pull complete
99b5ff394311: Pull complete
3ab3190bc52d: Pull complete
8f2bd7981235: Pull complete
ecefbdeeea30: Pull complete
402231b57661: Pull complete
3852eeb670e5: Pull complete
ed2241e55f9a: Pull complete
b647e348f228: Pull complete
Digest: sha256:659bf1e694f78315901da75538641bde5821e619ab604cf661c995a2890ce83b
Status: Downloaded newer image for japaric/mips64-unknown-linux-gnuabi64:latest
C:\Program Files\Docker\Docker\resources\bin\docker.exe: Error response from daemon: invalid volume specification: '/mnt/p/c/gh/cross:/project:ro'.
See 'C:\Program Files\Docker\Docker\resources\bin\docker.exe run --help'.
```