### PR TITLE
Add docker_context option to Cross.toml target options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ RUN dpkg --add-architecture arm64 && \
 $ docker build -t my/image:tag path/to/where/the/Dockerfile/resides
 ```
 
+`cross` can also use a local image and build it for you by specifying the path to
+the docker context using the target's `docker_context` variable:
+
+``` toml
+[target.aarch64-unknown-linux-gnu]
+docker_context = "ci/docker/aarch64-unknown-linux-gnu"
+```
+
+Note that `image` and `docker_context` are incompatible with each other.
+
 ### Passing environment variables into the build environment
 
 By default, `cross` does not pass any environment variables into the build

--- a/ci/crates/docker_context/Cargo.toml
+++ b/ci/crates/docker_context/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "docker_context"
+version = "0.1.0"
+authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+
+[dependencies]

--- a/ci/crates/docker_context/Cross.toml
+++ b/ci/crates/docker_context/Cross.toml
@@ -1,5 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
-docker_context = "ci/docker/aarch64-unknown-linux-gnu2"
+docker_context = "ci/aarch64-unknown-linux-gnu"
 
 [target.arm-unknown-linux-gnueabi]
 image = "japaric/arm-unknown-linux-gnueabi"

--- a/ci/crates/docker_context/Cross.toml
+++ b/ci/crates/docker_context/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+docker_context = "ci/docker/aarch64-unknown-linux-gnu2"
+
+[target.arm-unknown-linux-gnueabi]
+image = "japaric/arm-unknown-linux-gnueabi"

--- a/ci/crates/docker_context/ci/aarch64-unknown-linux-gnu
+++ b/ci/crates/docker_context/ci/aarch64-unknown-linux-gnu
@@ -1,0 +1,1 @@
+../../../../docker/aarch64-unknown-linux-gnu

--- a/ci/crates/docker_context/src/main.rs
+++ b/ci/crates/docker_context/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -178,6 +178,14 @@ EOF
 
         rm -rf $td
     fi
+
+    cd crates
+
+    cd docker_context
+    cross build --target $TARGET
+    cd ..
+
+    cd ..
 }
 
 cross_run() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,8 @@ pub struct Toml {
 
 impl Toml {
     /// Returns the `target.{}.image` part of `Cross.toml`
+    ///
+    /// Incompatible with the `docker_context` option.
     pub fn image(&self, target: &Target) -> Result<Option<&str>> {
         let triple = target.triple();
 
@@ -295,6 +297,23 @@ impl Toml {
             Ok(Some(value))
         } else {
             Ok(None)
+        }
+    }
+
+    /// Returns the `target.{}.docker_context` part of `Cross.toml`
+    ///
+    /// Incompatible with the `image` option.
+    pub fn context(&self, target: &Target) -> Result<Option<&str>> {
+        let triple = target.triple();
+
+        if let Some(value) = self.table
+            .lookup(&format!("target.{}.docker_context", triple)) {
+                Ok(Some(value.as_str()
+                        .ok_or_else(|| {
+                            format!("target.{}.docker_context must be a string", triple)
+                        })?))
+            } else {
+                Ok(None)
         }
     }
 


### PR DESCRIPTION
The docker_context option allows specifying a path to a local
docker context containing a Dockerfile. `cross` will then build
the docker file and use it as the docker image for that target.

Closes #196 .