### PR TITLE
Update Ubuntu version to 18.04

### DIFF
--- a/docker/aarch64-linux-android/Dockerfile
+++ b/docker/aarch64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/arm-linux-androideabi/Dockerfile
+++ b/docker/arm-linux-androideabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/arm-unknown-linux-musleabi/Dockerfile
+++ b/docker/arm-unknown-linux-musleabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/armv7-linux-androideabi/Dockerfile
+++ b/docker/armv7-linux-androideabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/armv7-unknown-linux-musleabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-musleabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/docker/asmjs-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/i686-linux-android/Dockerfile
+++ b/docker/i686-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/i686-pc-windows-gnu/Dockerfile
+++ b/docker/i686-pc-windows-gnu/Dockerfile
@@ -1,5 +1,4 @@
-# wine in ubuntu versions less than 17.04 hangs in the tests
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/i686-unknown-freebsd/Dockerfile
+++ b/docker/i686-unknown-freebsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/i686-unknown-linux-musl/Dockerfile
+++ b/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/ubuntu:16.04
+FROM i386/ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/sparcv9-sun-solaris/Dockerfile
+++ b/docker/sparcv9-sun-solaris/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/thumbv6m-none-eabi/Dockerfile
+++ b/docker/thumbv6m-none-eabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/thumbv7em-none-eabi/Dockerfile
+++ b/docker/thumbv7em-none-eabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/docker/thumbv7em-none-eabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/thumbv7m-none-eabi/Dockerfile
+++ b/docker/thumbv7m-none-eabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/docker/wasm32-unknown-emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-linux-android/Dockerfile
+++ b/docker/x86_64-linux-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-pc-windows-gnu/Dockerfile
+++ b/docker/x86_64-pc-windows-gnu/Dockerfile
@@ -1,5 +1,4 @@
-# wine in ubuntu versions less than 17.04 hangs in the tests
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-sun-solaris/Dockerfile
+++ b/docker/x86_64-sun-solaris/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-unknown-dragonfly/Dockerfile
+++ b/docker/x86_64-unknown-dragonfly/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/docker/x86_64-unknown-freebsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-unknown-netbsd/Dockerfile
+++ b/docker/x86_64-unknown-netbsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The images that do not rely on an old glibc being available are updated to the new LTS version.