### PR TITLE
Fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,11 @@ matrix:
     - env: TARGET=thumbv7em-none-eabihf                         STD=1
     - env: TARGET=thumbv7m-none-eabi                            STD=1
 
+  allow_failures:
+    # FIXME: error undefined reference to symbol 'setvbuf'
+    - env: TARGET=x86_64-unknown-netbsd           CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
+
+
 install:
   - curl https://sh.rustup.rs -sSf |
     sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,10 @@ matrix:
       rust: nightly-2017-10-24
 
     # Bare metal
-    - env: TARGET=thumbv6m-none-eabi                                                 RUN=1
-    - env: TARGET=thumbv7em-none-eabi                                                RUN=1
-    - env: TARGET=thumbv7em-none-eabihf                                              RUN=1
-    - env: TARGET=thumbv7m-none-eabi                                                 RUN=1
+    - env: TARGET=thumbv6m-none-eabi                            STD=1
+    - env: TARGET=thumbv7em-none-eabi                           STD=1
+    - env: TARGET=thumbv7em-none-eabihf                         STD=1
+    - env: TARGET=thumbv7m-none-eabi                            STD=1
 
 install:
   - curl https://sh.rustup.rs -sSf |

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,6 @@ matrix:
     - env: TARGET=thumbv7em-none-eabihf                         STD=1
     - env: TARGET=thumbv7m-none-eabi                            STD=1
 
-  allow_failures:
-    # FIXME: error undefined reference to symbol 'setvbuf'
-    - env: TARGET=x86_64-unknown-netbsd           CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
-
 
 install:
   - curl https://sh.rustup.rs -sSf |

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,11 @@ matrix:
     - env: TARGET=thumbv7m-none-eabi                            STD=1
 
 
+before_install:
+  # workaround for https://github.com/travis-ci/travis-ci/issues/4704
+  - python3 -c 'import os,sys; os.set_blocking(sys.stdout.fileno(), True)'
+
+
 install:
   - curl https://sh.rustup.rs -sSf |
     sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,10 @@ matrix:
       os: osx
 
     # BSD
-    - env: TARGET=i686-unknown-freebsd            CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
+    # FIXME: freebsd fails to link when CPP=1
+    - env: TARGET=i686-unknown-freebsd                  DYLIB=1 STD=1 OPENSSL=0.7.17
     - env: TARGET=x86_64-unknown-dragonfly        CPP=1 DYLIB=1       OPENSSL=0.5.5
-    - env: TARGET=x86_64-unknown-freebsd          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5
+    - env: TARGET=x86_64-unknown-freebsd                DYLIB=1 STD=1 OPENSSL=0.5.5
     - env: TARGET=x86_64-unknown-netbsd           CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
 
     # Solaris

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,20 +35,20 @@ matrix:
     - env: TARGET=x86_64-linux-android            CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
 
     # OSX
-    - env: TARGET=i686-apple-darwin                     DYLIB=1 STD=1                RUN=1
+    - env: TARGET=i686-apple-darwin               CPP=1 DYLIB=1 STD=1                RUN=1
       os: osx
-    - env: TARGET=x86_64-apple-darwin                   DYLIB=1 STD=1                RUN=1 DEPLOY=1
+    - env: TARGET=x86_64-apple-darwin             CPP=1 DYLIB=1 STD=1                RUN=1 DEPLOY=1
       os: osx
 
     # BSD
-    - env: TARGET=i686-unknown-freebsd                  DYLIB=1 STD=1 OPENSSL=0.7.17
-    - env: TARGET=x86_64-unknown-dragonfly              DYLIB=1       OPENSSL=0.5.5
-    - env: TARGET=x86_64-unknown-freebsd                DYLIB=1 STD=1 OPENSSL=0.5.5
-    - env: TARGET=x86_64-unknown-netbsd                 DYLIB=1 STD=1 OPENSSL=0.7.17
+    - env: TARGET=i686-unknown-freebsd            CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
+    - env: TARGET=x86_64-unknown-dragonfly        CPP=1 DYLIB=1       OPENSSL=0.5.5
+    - env: TARGET=x86_64-unknown-freebsd          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5
+    - env: TARGET=x86_64-unknown-netbsd           CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
 
     # Solaris
-    - env: TARGET=sparcv9-sun-solaris                   DYLIB=1 STD=1 OPENSSL=0.7.17
-    - env: TARGET=x86_64-sun-solaris                    DYLIB=1 STD=1 OPENSSL=0.7.17
+    - env: TARGET=sparcv9-sun-solaris             CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
+    - env: TARGET=x86_64-sun-solaris              CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17
 
     # Windows
     - env: TARGET=x86_64-pc-windows-gnu           CPP=1         STD=1                RUN=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,105 +1,85 @@
 [[package]]
 name = "backtrace"
-version = "0.3.0"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.5"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cross"
 version = "0.1.15-dev"
 dependencies = [
- "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "dbghelp-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "error-chain"
-version = "0.7.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gcc"
-version = "0.3.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "0.2.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.18"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.3"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "semver"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,34 +95,42 @@ name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f551bc2ddd53aea015d453ef0b635af89444afa5ed2405dd0b2062ad5d600d80"
-"checksum backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3602e8d8c43336088a8505fa55cae2b3884a9be29440863a11528a42f46f6bb7"
-"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
-"checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
-"checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
-"checksum rustc-demangle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1430d286cadb237c17c885e25447c982c97113926bb579f4379c0eca8d9586dc"
-"checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
-"checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
-"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
+"checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
+"checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/japaric/cross"
 version = "0.1.15-dev"
 
 [dependencies]
-error-chain = "0.7.1"
-lazy_static = "0.2"
+error-chain = "0.12"
+lazy_static = "1.0"
 libc = "0.2.18"
 rustc_version = "0.2.1"
-semver = "0.6.0"
+semver = "0.9.0"
 toml = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ worst, "hang" (never terminate).
 | `asmjs-unknown-emscripten` [4]       | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-linux-android` [5]             | N/A    | 4.9     | 1.0.2m  | ✓   | N/A   |   ✓    |
-| `i686-pc-windows-gnu`                | N/A    | 6.2.0   | N/A     | ✓   | N/A   |   ✓    |
+| `i686-pc-windows-gnu`                | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
 | `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.15 | 5.3.1   | 1.0.2m  |     | N/A   |   ✓    |
@@ -220,7 +220,7 @@ worst, "hang" (never terminate).
 | `thumbv7m-none-eabi` [3]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
 | `wasm32-unknown-emscripten` [4]      | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
 | `x86_64-linux-android` [5]           | N/A    | 4.9     | 1.0.2m  | ✓   | N/A   |   ✓    |
-| `x86_64-pc-windows-gnu`              | N/A    | 6.2.0   | N/A     | ✓   | N/A   |   ✓    |
+| `x86_64-pc-windows-gnu`              | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
 | `x86_64-sun-solaris` [1]             | 2.11   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ worst, "hang" (never terminate).
 | `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-linux-android` [5]             | N/A    | 4.9     | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
-| `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
+| `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2m  |     | N/A   |        |
 | `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.15 | 5.3.1   | 1.0.2m  |     | N/A   |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2m  | ✓   | 2.8.0 |   ✓    |
@@ -223,7 +223,7 @@ worst, "hang" (never terminate).
 | `x86_64-pc-windows-gnu`              | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
 | `x86_64-sun-solaris` [1]             | 2.11   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
-| `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
+| `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2m  |     | N/A   |        |
 | `x86_64-unknown-linux-gnu`           | 2.15   | 4.6.2   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-linux-musl`          | 1.1.15 | 5.3.1   | 1.0.2m  |     | N/A   |   ✓    |
 | `x86_64-unknown-netbsd`[1]           | 7.0    | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -113,10 +113,7 @@ EOF
                 $td
 
             pushd $td
-            cross test \
-                  --no-default-features \
-                  --features "gen-tests mangled-names" \
-                  --target $TARGET
+            cross test --manifest-path testcrate/Cargo.toml --target $TARGET
             popd
 
             rm -rf $td

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -94,6 +94,7 @@ EOF
         git clone --depth 1 https://github.com/japaric/xargo $td
 
         pushd $td
+        sed -i -e 's/unused_doc_comment/unused_doc_comments/g' src/errors.rs
         cross build --target $TARGET
         popd
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -26,24 +26,6 @@ main() {
         rm -rf $td
     fi
 
-    # `cross run` test for thumb targets
-    case $TARGET in
-        thumb*-none-eabi*)
-            td=$(mktemp -d)
-
-            git clone \
-                --depth 1 \
-                --recursive \
-                https://github.com/japaric/cortest $td
-
-            pushd $td
-            cross run --target $TARGET --example hello --release
-            popd
-
-            rm -rf $td
-        ;;
-    esac
-
     # `cross build` test for targets where `std` is not available
     if [ -z "$STD" ]; then
         td=$(mktemp -d)
@@ -88,7 +70,7 @@ EOF
         popd
 
         rm -rf $td
-    else
+    elif [[ "$TARGET" != thumb* ]]; then
         td=$(mktemp -d)
 
         git clone --depth 1 https://github.com/japaric/xargo $td
@@ -120,20 +102,39 @@ EOF
         fi
 
         # `cross run` test
-        td=$(mktemp -d)
+        case $TARGET in
+            thumb*-none-eabi*)
+                td=$(mktemp -d)
 
-        cargo init --bin --name hello $td
+                git clone \
+                    --depth 1 \
+                    --recursive \
+                    https://github.com/japaric/cortest $td
 
-        pushd $td
-        mkdir examples tests
-        echo "fn main() { println!(\"Example!\"); }" > examples/e.rs
-        echo "#[test] fn t() {}" > tests/t.rs
-        cross run --target $TARGET
-        cross run --target $TARGET --example e
-        cross test --target $TARGET
-        popd
+                pushd $td
+                cross run --target $TARGET --example hello --release
+                popd
 
-        rm -rf $td
+                rm -rf $td
+            ;;
+            *)
+                td=$(mktemp -d)
+
+                cargo init --bin --name hello $td
+
+                pushd $td
+                mkdir examples tests
+                echo "fn main() { println!(\"Example!\"); }" > examples/e.rs
+                echo "#[test] fn t() {}" > tests/t.rs
+                cross run --target $TARGET
+                cross run --target $TARGET --example e
+                cross test --target $TARGET
+                popd
+
+                rm -rf $td
+            ;;
+        esac
+
     fi
 
     # Test C++ support

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -76,6 +76,7 @@ EOF
         git clone --depth 1 https://github.com/japaric/xargo $td
 
         pushd $td
+        sed -i -e 's/#!\[deny(warnings)\]//g' src/main.rs
         sed -i -e 's/unused_doc_comment/unused_doc_comments/g' src/errors.rs
         cross build --target $TARGET
         popd

--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -40,6 +40,7 @@ main() {
     pushd $td
 
     cd gcc
+    sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     patch -p0 <<'EOF'
 --- libatomic/configure.tgt.orig	2015-07-09 16:08:55 UTC

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -53,7 +53,7 @@ main() {
             ;;
     esac
 
-    curl ftp://ftp.freebsd.org/pub/FreeBSD/releases/$bsd_arch/10.2-RELEASE/base.txz | \
+    curl http://ftp.freebsd.org/pub/FreeBSD/releases/$bsd_arch/10.2-RELEASE/base.txz | \
         tar -C $td/freebsd -xJ ./usr/include ./usr/lib ./lib
 
     cd binutils-build

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -69,11 +69,14 @@ main() {
     cp $td/freebsd/lib/libm.so.5 $destdir/lib
     cp $td/freebsd/lib/libthr.so.3 $destdir/lib/libpthread.so
     cp $td/freebsd/lib/libutil.so.9 $destdir/lib
+    cp $td/freebsd/usr/lib/libc++.so.1 $destdir/lib
+    cp $td/freebsd/usr/lib/libc++.a $destdir/lib
     cp $td/freebsd/usr/lib/lib{c,util,m}.a $destdir/lib
     cp $td/freebsd/usr/lib/lib{rt,execinfo}.so.1 $destdir/lib
     cp $td/freebsd/usr/lib/{crt1,Scrt1,crti,crtn}.o $destdir/lib
 
     ln -s libc.so.7 $destdir/lib/libc.so
+    ln -s libc++.so.1 $destdir/lib/libc++.so
     ln -s libexecinfo.so.1 $destdir/lib/libexecinfo.so
     ln -s libm.so.5 $destdir/lib/libm.so
     ln -s librt.so.1 $destdir/lib/librt.so

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -39,6 +39,7 @@ main() {
     pushd $td
 
     cd gcc
+    sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     cd ..
 

--- a/docker/i686-pc-windows-gnu/Dockerfile
+++ b/docker/i686-pc-windows-gnu/Dockerfile
@@ -1,5 +1,4 @@
-# wine in ubuntu versions less than 17.04 hangs in the tests
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -40,5 +39,5 @@ ENTRYPOINT ["/windows-entry.sh"]
 
 ENV CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER=i686-w64-mingw32-gcc \
     CARGO_TARGET_I686_PC_WINDOWS_GNU_RUNNER=wine \
-    CC_i686_pc_windows_gnu=i686-w64-mingw32-gcc \
-    CXX_i686_pc_windows_gnu=i686-w64-mingw32-g++
+    CC_i686_pc_windows_gnu=i686-w64-mingw32-gcc-posix \
+    CXX_i686_pc_windows_gnu=i686-w64-mingw32-g++-posix

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -41,8 +41,8 @@ main() {
     sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     local patches=(
-        ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
-        ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__configure__char.cc
+        ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2017Q1/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
+        ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2017Q1/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__configure__char.cc
     )
 
     local patch

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -38,6 +38,7 @@ main() {
     pushd $td
 
     cd gcc
+    sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     local patches=(
         ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-2016Q4/pkgsrc/lang/gcc5/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h

--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -40,6 +40,7 @@ main() {
     pushd $td
 
     cd gcc
+    sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     cd ..
 

--- a/docker/windows-entry.sh
+++ b/docker/windows-entry.sh
@@ -14,6 +14,6 @@ wineboot &> /dev/null
 # Put libstdc++ and some other mingw dlls in WINEPATH
 # This must work for x86_64 and i686
 P1=$(dirname $(find /usr -name libwinpthread-1.dll))
-export WINEPATH="$(ls -d /usr/lib/gcc/*-w64-mingw32/*win32);$P1"
+export WINEPATH="$(ls -d /usr/lib/gcc/*-w64-mingw32/*posix);$P1"
 
 exec "$@"

--- a/docker/x86_64-pc-windows-gnu/Dockerfile
+++ b/docker/x86_64-pc-windows-gnu/Dockerfile
@@ -1,5 +1,4 @@
-# wine in ubuntu versions less than 17.04 hangs in the tests
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -38,5 +37,5 @@ ENTRYPOINT ["/windows-entry.sh"]
 
 ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine \
-    CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
-    CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++
+    CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc-posix \
+    CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++-posix

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,3 @@
-#![allow(unused_doc_comment)]
+#![allow(unused_doc_comments)]
 
 error_chain!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,7 @@ impl Target {
     }
 
     fn needs_xargo(&self) -> bool {
-        self.is_bare_metal() || !self.is_builtin()
+        !self.is_builtin()
     }
 }
 


### PR DESCRIPTION
This fixes almost all current build issues.  Only two issues are left:

- thumb* tests, which requires using https://github.com/japaric/utest instead of https://github.com/japaric/cortest
- netbsd build, which is failing with libc linking issues