### PR TITLE
remove export to make CI process less verbose

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -13,8 +13,6 @@ main() {
 
     cargo install --force --path .
 
-    export QEMU_STRACE=1
-
     # test `cross check`
     if [ ! -z $STD ]; then
         td=$(mktemp -d)


### PR DESCRIPTION
The bors builds are failing probably because of the verbosity of the build. Removing this as per [this comment](https://github.com/rust-embedded/cross/pull/206#issuecomment-425641154)