### PR TITLE
Simplify Target to use only to cases: BuiltIn and Custom

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::error::Error;
-use std::fs::File;
+use std::fs::{read_dir, File};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
@@ -21,6 +21,11 @@ fn main() {
     File::create(out_dir.join("commit-info.txt"))
         .unwrap()
         .write_all(commit_info().as_bytes())
+        .unwrap();
+
+    File::create(out_dir.join("docker-images.rs"))
+        .unwrap()
+        .write_all(docker_images().as_bytes())
         .unwrap();
 }
 
@@ -52,4 +57,20 @@ fn commit_date() -> Result<String, Some> {
     } else {
         Err(Some {})
     }
+}
+
+fn docker_images() -> String {
+    let mut images = String::from("[");
+    let mut dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    dir.push("docker");
+    for entry in read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            images.push_str("\"");
+            images.push_str(path.file_name().unwrap().to_str().unwrap());
+            images.push_str("\", ");
+        }
+    }
+    images.push_str("]");
+    images
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ impl Target {
     }
 
     fn is_bsd(&self) -> bool {
-        self.triple().contains("bsd")
+        self.triple().contains("bsd") || self.triple().contains("dragonfly")
     }
 
     fn is_solaris(&self) -> bool {


### PR DESCRIPTION
In the current form, cross needs to known every target its supports.
This makes things too restrict. For example, its not possible to use a
custom target image for a target that cross does not provides a docker
image (like aarch64-unknown-linux-musl, for example). Cross refuses to
execute saying it does not support the specified target. Besides that,
to add a new docker image the cross code needs to be changed.

This changes simplifies the Target enum to have only two variants:
BuiltIn and Custom. Cross needs to known if a target is a custom target
so it can call xargo, otherwise, all BuitIn targets can be uniformly
handled.