### PR TITLE
Add more utilities to the Docker images.

### DIFF
--- a/docker/aarch64-linux-android/Dockerfile
+++ b/docker/aarch64-linux-android/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/aarch64-linux-android/Dockerfile
+++ b/docker/aarch64-linux-android/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/arm-linux-androideabi/Dockerfile
+++ b/docker/arm-linux-androideabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/arm-linux-androideabi/Dockerfile
+++ b/docker/arm-linux-androideabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/arm-unknown-linux-musleabi/Dockerfile
+++ b/docker/arm-unknown-linux-musleabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/arm-unknown-linux-musleabi/Dockerfile
+++ b/docker/arm-unknown-linux-musleabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/armv5te-unknown-linux-musleabi/Dockerfile
+++ b/docker/armv5te-unknown-linux-musleabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/armv5te-unknown-linux-musleabi/Dockerfile
+++ b/docker/armv5te-unknown-linux-musleabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/armv7-linux-androideabi/Dockerfile
+++ b/docker/armv7-linux-androideabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/armv7-linux-androideabi/Dockerfile
+++ b/docker/armv7-linux-androideabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/armv7-unknown-linux-musleabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-musleabihf/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/armv7-unknown-linux-musleabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-musleabihf/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/docker/asmjs-unknown-emscripten/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 RUN apt-get install -y --no-install-recommends python
 

--- a/docker/asmjs-unknown-emscripten/Dockerfile
+++ b/docker/asmjs-unknown-emscripten/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/docker/i586-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/docker/i586-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i586-unknown-linux-musl/Dockerfile
+++ b/docker/i586-unknown-linux-musl/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i586-unknown-linux-musl/Dockerfile
+++ b/docker/i586-unknown-linux-musl/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i686-linux-android/Dockerfile
+++ b/docker/i686-linux-android/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i686-linux-android/Dockerfile
+++ b/docker/i686-linux-android/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i686-pc-windows-gnu/Dockerfile
+++ b/docker/i686-pc-windows-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i686-pc-windows-gnu/Dockerfile
+++ b/docker/i686-pc-windows-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i686-unknown-freebsd/Dockerfile
+++ b/docker/i686-unknown-freebsd/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i686-unknown-freebsd/Dockerfile
+++ b/docker/i686-unknown-freebsd/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/i686-unknown-linux-musl/Dockerfile
+++ b/docker/i686-unknown-linux-musl/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/i686-unknown-linux-musl/Dockerfile
+++ b/docker/i686-unknown-linux-musl/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/docker/mips-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/docker/mips-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/mips-unknown-linux-musl/Dockerfile
+++ b/docker/mips-unknown-linux-musl/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/mips-unknown-linux-musl/Dockerfile
+++ b/docker/mips-unknown-linux-musl/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/sparcv9-sun-solaris/Dockerfile
+++ b/docker/sparcv9-sun-solaris/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/sparcv9-sun-solaris/Dockerfile
+++ b/docker/sparcv9-sun-solaris/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/thumbv6m-none-eabi/Dockerfile
+++ b/docker/thumbv6m-none-eabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/thumbv6m-none-eabi/Dockerfile
+++ b/docker/thumbv6m-none-eabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/thumbv7em-none-eabi/Dockerfile
+++ b/docker/thumbv7em-none-eabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/thumbv7em-none-eabi/Dockerfile
+++ b/docker/thumbv7em-none-eabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/docker/thumbv7em-none-eabihf/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/docker/thumbv7em-none-eabihf/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/thumbv7m-none-eabi/Dockerfile
+++ b/docker/thumbv7m-none-eabi/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/thumbv7m-none-eabi/Dockerfile
+++ b/docker/thumbv7m-none-eabi/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/docker/wasm32-unknown-emscripten/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 RUN apt-get install -y --no-install-recommends python
 

--- a/docker/wasm32-unknown-emscripten/Dockerfile
+++ b/docker/wasm32-unknown-emscripten/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-linux-android/Dockerfile
+++ b/docker/x86_64-linux-android/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-linux-android/Dockerfile
+++ b/docker/x86_64-linux-android/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-pc-windows-gnu/Dockerfile
+++ b/docker/x86_64-pc-windows-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-pc-windows-gnu/Dockerfile
+++ b/docker/x86_64-pc-windows-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-sun-solaris/Dockerfile
+++ b/docker/x86_64-sun-solaris/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-sun-solaris/Dockerfile
+++ b/docker/x86_64-sun-solaris/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-unknown-dragonfly/Dockerfile
+++ b/docker/x86_64-unknown-dragonfly/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-unknown-dragonfly/Dockerfile
+++ b/docker/x86_64-unknown-dragonfly/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/docker/x86_64-unknown-freebsd/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/docker/x86_64-unknown-freebsd/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \

--- a/docker/x86_64-unknown-netbsd/Dockerfile
+++ b/docker/x86_64-unknown-netbsd/Dockerfile
@@ -7,7 +7,16 @@ RUN apt-get update && \
     gcc \
     libc6-dev \
     make \
-    pkg-config
+    pkg-config \
+    g++ \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
 
 COPY xargo.sh /
 RUN bash /xargo.sh

--- a/docker/x86_64-unknown-netbsd/Dockerfile
+++ b/docker/x86_64-unknown-netbsd/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
     libc6-dev \
     make \
     pkg-config \
-    g++ \
     git \
     automake \
     libtool \


### PR DESCRIPTION
This PR adds the following utilities to all docker containers - these allows the
utilities to be used in `build.rs` while cross-compiling: g++, git, automake,
libtool, m4, autoconf, make, file, binutils.