### PR TITLE
Update emscripten

### DIFF
--- a/docker/emscripten.sh
+++ b/docker/emscripten.sh
@@ -26,8 +26,8 @@ main() {
     export HOME=/emsdk-portable/
 
     ./emsdk update
-    ./emsdk install sdk-1.37.21-64bit
-    ./emsdk activate sdk-1.37.21-64bit
+    ./emsdk install sdk-1.38.15-64bit
+    ./emsdk activate sdk-1.38.15-64bit
 
     # Compile and cache libc
     source ./emsdk_env.sh


### PR DESCRIPTION
rustc switched to emscripten with LLVM 6. emscripten versions with LLVM 4 are not supported anymore. This upgrades emscripten to the same version as rustc is using in its CI.