### PR TITLE
Add DOCKER_OPTS variable

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -126,6 +126,11 @@ pub fn run(target: &Target,
         docker.args(&["-e", &format!("CROSS_DEBUG={}", value)]);
     }
 
+    if let Some(value) = env::var("DOCKER_OPTS").ok() {
+        let opts: Vec<&str> = value.split(" ").collect();
+        docker.args(&opts);
+    }
+
     let mut runner = None;
 
     if let Some(toml) = toml {


### PR DESCRIPTION
This PR add DOCKER_OPTS variable to pass some custom options to `docker run`.
For example, the crate using `ptrace` syscall internally can't be tested by cross, because `ptrace` is not allowed in docker by default.
So I want to specify additional options to allow `ptrace` like below.

```
DOCKER_OPTS="--cap-add=SYS_PTRACE --security-opt=seccomp=unconfined" cross test
```