### PR TITLE
`cargo bench` needs an interpreter like `cargo test`.

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -91,6 +91,7 @@ EOF
             pushd $td
             cargo init --lib --name foo .
             cross_test --target $TARGET
+            cross_bench --target $TARGET
             popd
 
             rm -rf $td
@@ -124,6 +125,7 @@ EOF
                 cross_run --target $TARGET
                 cross_run --target $TARGET --example e
                 cross_test --target $TARGET
+                cross_bench --target $TARGET
                 popd
 
                 rm -rf $td
@@ -192,6 +194,17 @@ cross_test() {
         for runner in $RUNNERS; do
             echo -e "[target.$TARGET]\nrunner = \"$runner\"" > Cross.toml
             cross test "$@"
+        done
+    fi
+}
+
+cross_bench() {
+    if [ -z "$RUNNERS" ]; then
+        cross bench "$@"
+    else
+        for runner in $RUNNERS; do
+            echo -e "[target.$TARGET]\nrunner = \"$runner\"" > Cross.toml
+            cross bench "$@"
         done
     fi
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -13,6 +13,7 @@ pub enum Subcommand {
     Run,
     Rustc,
     Test,
+    Bench,
     Deb,
 }
 
@@ -26,7 +27,7 @@ impl Subcommand {
 
     pub fn needs_interpreter(&self) -> bool {
         match *self {
-            Subcommand::Run | Subcommand::Test => true,
+            Subcommand::Run | Subcommand::Test | Subcommand::Bench => true,
             _ => false,
         }
     }
@@ -40,6 +41,7 @@ impl<'a> From<&'a str> for Subcommand {
             "run" => Subcommand::Run,
             "rustc" => Subcommand::Rustc,
             "test" => Subcommand::Test,
+            "bench" => Subcommand::Bench,
             "deb" => Subcommand::Deb,
             _ => Subcommand::Other,
         }


### PR DESCRIPTION
Without this, rustc was being run outside docker and thus not running
with the correct system tools and libraries.

Fixes #239.