### PR TITLE
Fix toolchain path on macOS.

### DIFF
--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -ex
 
 run() {

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -43,7 +43,7 @@ main() {
         powerpc64)
             # there is no stable port
             arch=ppc64
-            kernel=4.18.0-3-powerpc64
+            kernel=4.19.0-1-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies
@@ -59,7 +59,7 @@ main() {
             ;;
         sparc64)
             # there is no stable port
-            kernel=4.18.0-3-sparc64
+            kernel=4.19.0-1-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
             # sid version of dropbear requeries this depencendies

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -5,7 +5,7 @@ use std::{env, fs};
 use errors::*;
 use extensions::CommandExt;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Subcommand {
     Build,
     Check,
@@ -48,6 +48,7 @@ impl<'a> From<&'a str> for Subcommand {
     }
 }
 
+#[derive(Debug)]
 pub struct Root {
     path: PathBuf,
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -10,7 +10,6 @@ use cargo::Root;
 use errors::*;
 use extensions::CommandExt;
 use id;
-use rustc;
 
 const DOCKER_IMAGES: &[&str] = &include!(concat!(env!("OUT_DIR"), "/docker-images.rs"));
 
@@ -74,6 +73,7 @@ pub fn run(target: &Target,
            root: &Root,
            toml: Option<&Toml>,
            uses_xargo: bool,
+           sysroot: &PathBuf,
            verbose: bool)
            -> Result<ExitStatus> {
     let root = root.path();
@@ -156,7 +156,7 @@ pub fn run(target: &Target,
         .args(&["-v", &format!("{}:/xargo", xargo_dir.display())])
         .args(&["-v", &format!("{}:/cargo", cargo_dir.display())])
         .args(&["-v", &format!("{}:/project:ro", root.display())])
-        .args(&["-v", &format!("{}:/rust:ro", rustc::sysroot(verbose)?.display())])
+        .args(&["-v", &format!("{}:/rust:ro", sysroot.display())])
         .args(&["-v", &format!("{}:/target", target_dir.display())])
         .args(&["-w", "/project"])
         .args(&["-it", &image(toml, target)?])

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
@@ -29,7 +31,7 @@ use errors::*;
 use rustc::{TargetList, VersionMetaExt};
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Host {
     Other,
 
@@ -73,7 +75,7 @@ impl<'a> From<&'a str> for Host {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Target {
     BuiltIn { triple: String },
     Custom { triple: String },
@@ -263,6 +265,7 @@ fn run() -> Result<ExitStatus> {
 
 
 /// Parsed `Cross.toml`
+#[derive(Debug)]
 pub struct Toml {
     table: Value,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ impl Host {
     /// `target == None` means `target == host`
     fn is_supported(&self, target: Option<&Target>) -> bool {
         if *self == Host::X86_64AppleDarwin {
-            target.map(|t| t.triple() == "i686-apple-darwin").unwrap_or(false)
+            target.map(|t| t.triple() == "i686-apple-darwin" || t.needs_docker()).unwrap_or(false)
         } else if *self == Host::X86_64UnknownLinuxGnu {
             target.map(|t| t.needs_docker()).unwrap_or(true)
         } else {
@@ -223,7 +223,18 @@ fn run() -> Result<ExitStatus> {
             let target = args.target
                 .unwrap_or(Target::from(host.triple(), &target_list));
             let toml = toml(&root)?;
-            let available_targets = rustup::available_targets(verbose)?;
+
+            let sysroot = rustc::sysroot(verbose)?;
+            let toolchain = sysroot.file_name().and_then(|file_name| file_name.to_str())
+                .ok_or("couldn't get toolchain name")?;
+
+            let installed_toolchains = rustup::installed_toolchains(verbose)?;
+
+            if !installed_toolchains.into_iter().any(|t| t == toolchain) {
+              rustup::install_toolchain(&toolchain, verbose)?;
+            }
+
+            let available_targets = rustup::available_targets(&toolchain, verbose)?;
             let uses_xargo = !target.is_builtin() ||
                 !available_targets.contains(&target) ||
                 if let Some(toml) = toml.as_ref() {
@@ -234,7 +245,7 @@ fn run() -> Result<ExitStatus> {
                 .unwrap_or(false);
 
             if !uses_xargo && !available_targets.is_installed(&target) {
-                rustup::install(&target, verbose)?;
+                rustup::install(&target, &toolchain, verbose)?;
             } else if !rustup::rust_src_is_installed(verbose)? {
                 rustup::install_rust_src(verbose)?;
             }
@@ -255,6 +266,7 @@ fn run() -> Result<ExitStatus> {
                                    &root,
                                    toml.as_ref(),
                                    uses_xargo,
+                                   &sysroot,
                                    verbose);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ fn run() -> Result<ExitStatus> {
                 .unwrap_or(Target::from(host.triple(), &target_list));
             let toml = toml(&root)?;
 
-            let sysroot = rustc::sysroot(verbose)?;
+            let sysroot = rustc::sysroot(&host, &target, verbose)?;
             let toolchain = sysroot.file_name().and_then(|file_name| file_name.to_str())
                 .ok_or("couldn't get toolchain name")?;
 


### PR DESCRIPTION
This automatically installs the Linux toolchain on macOS, so it can be used by the Docker images, and then installs the targets for the Linux toolchain instead of the default one.