### PR TITLE
Add `arm-linux-gnueabihf`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system" CROSS_DEBUG=1
     - env: TARGET=arm-unknown-linux-gnueabi       CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=arm-unknown-linux-gnueabihf     CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=armv7-unknown-linux-gnueabihf   CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="qemu-user qemu-system"
     - env: TARGET=i586-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=i686-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1 RUNNERS="native qemu-user qemu-system"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![crates.io](https://img.shields.io/crates/v/cross.svg)](https://crates.io/crates/cross)
 [![crates.io](https://img.shields.io/crates/d/cross.svg)](https://crates.io/crates/cross)
-[![Build Status](https://travis-ci.org/rust-embedded/cross.svg?branch=master)](https://travis-ci.org/rust-embedded/cross) 
+[![Build Status](https://travis-ci.org/rust-embedded/cross.svg?branch=master)](https://travis-ci.org/rust-embedded/cross)
 
 # `cross`
 
@@ -196,6 +196,7 @@ worst, "hang" (never terminate).
 | `aarch64-unknown-linux-musl`         | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `arm-linux-androideabi` [5]          | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
+| `arm-unknown-linux-gnueabihf`        | 2.19   | 4.8.3   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabihf`       | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `armv5te-unknown-linux-musleabi`     | 1.1.20 | 6.3.0   |  N/A    |     | 2.8.0 |   ✓    |

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ worst, "hang" (never terminate).
 | `aarch64-unknown-linux-musl`         | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `arm-linux-androideabi` [5]          | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
-| `arm-unknown-linux-gnueabihf`        | 2.19   | 4.8.3   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
+| `arm-unknown-linux-gnueabihf`        | 2.27   | 7.3.0   | 1.0.2p  | ✓   | 2.10  |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabihf`       | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `armv5te-unknown-linux-musleabi`     | 1.1.20 | 6.3.0   |  N/A    |     | 2.8.0 |   ✓    |

--- a/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -24,26 +24,29 @@ COPY cmake.sh /
 RUN apt-get purge --auto-remove -y cmake && \
     bash /cmake.sh 3.5.1
 
-RUN git clone --depth 1 https://github.com/raspberrypi/tools.git /pi-tools && \
-    mv /pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64 /usr/arm-linux-gnueabihf && \
-    mv /pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot /usr/arm-linux-gnueabihf/sysroot && \
-    rm -r /pi-tools
-
-ENV PATH /usr/arm-linux-gnueabihf/bin:$PATH
+RUN mkdir /usr/arm-linux-gnueabihf && \
+    apt-get install -y --no-install-recommends curl && \
+    cd /usr/arm-linux-gnueabihf && \
+    curl -L https://toolchains.bootlin.com/downloads/releases/toolchains/armv6-eabihf/tarballs/armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 | \
+    tar --strip-components 1 -xj && \
+    apt-get purge --auto-remove -y curl
 
 COPY openssl.sh qemu.sh /
+
+RUN bash /qemu.sh arm
+ENV PATH /usr/arm-linux-gnueabihf/bin:$PATH
+
 RUN apt-get install -y --no-install-recommends \
     libc6-dev-armhf-cross && \
-    bash /openssl.sh linux-armv4 arm-linux-gnueabihf- && \
-    bash /qemu.sh arm
+    bash /openssl.sh linux-armv4 arm-linux-
 
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm \
-    CC_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
-    CXX_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+    CC_arm_unknown_linux_gnueabihf=arm-linux-gcc \
+    CXX_arm_unknown_linux_gnueabihf=arm-linux-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
-    LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib:/usr/arm-linux-gnueabihf/sysroot/lib \
+    LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib:/usr/arm-linux-gnueabihf/arm-buildroot-linux-gnueabihf/lib \
     RUST_TEST_THREADS=1

--- a/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    gcc \
+    libc6-dev \
+    make \
+    pkg-config \
+    git \
+    automake \
+    libtool \
+    m4 \
+    autoconf \
+    make \
+    file \
+    binutils
+
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY cmake.sh /
+RUN apt-get purge --auto-remove -y cmake && \
+    bash /cmake.sh 3.5.1
+
+RUN git clone --depth 1 https://github.com/raspberrypi/tools.git /pi-tools && \
+    mv /pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64 /usr/arm-linux-gnueabihf && \
+    mv /pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot /usr/arm-linux-gnueabihf/sysroot && \
+    rm -r /pi-tools
+
+ENV PATH /usr/arm-linux-gnueabihf/bin:$PATH
+
+COPY openssl.sh qemu.sh /
+RUN apt-get install -y --no-install-recommends \
+    libc6-dev-armhf-cross && \
+    bash /openssl.sh linux-armv4 arm-linux-gnueabihf- && \
+    bash /qemu.sh arm
+
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm \
+    CC_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    CXX_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include \
+    OPENSSL_LIB_DIR=/openssl/lib \
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
+    LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib:/usr/arm-linux-gnueabihf/sysroot/lib \
+    RUST_TEST_THREADS=1


### PR DESCRIPTION
I took the suggestion from https://github.com/rust-embedded/cross/pull/158#issuecomment-360763050 and used a pre-compiled toolchain.

There are two commits here, the first one uses https://github.com/raspberrypi/tools, in the second one I switched to https://toolchains.bootlin.com/releases_armv6-eabihf.html.

I am not sure however if the `sysroot` is set correctly, since everything except `qemu` also works without `LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib:/usr/arm-linux-gnueabihf/arm-buildroot-linux-gnueabihf/lib`.