### PR TITLE
 Add support for clippy.

### DIFF
--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -86,7 +86,7 @@ EOF
 EOF
     cd ..
 
-    curl https://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-$dragonfly.iso.bz2 | \
+    curl https://mirrors.dotsrc.org/dragonflybsd/iso-images/dfly-x86_64-$dragonfly.iso.bz2 | \
         bzcat | \
         bsdtar xf - -C $td/dragonfly ./usr/include ./usr/lib ./lib
 

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -104,7 +104,7 @@ main() {
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 9D6D8F6BC857C906
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 8B48AD6246925553
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 7638D0442B90D010
-    apt-key adv --recv-key --keyserver keyserver.ubuntu.com 8BC3A7D46F930576 # ports
+    apt-key adv --recv-key --keyserver keyserver.ubuntu.com DA1B2CEA81DCBC61 # debian-ports
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com CBF8D6FD518E17E1
     apt-key adv --recv-key --keyserver keyserver.ubuntu.com 06AED62430CB581C
     apt-get update

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -5,7 +5,7 @@ use std::{env, fs};
 use errors::*;
 use extensions::CommandExt;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Subcommand {
     Build,
     Check,

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -15,6 +15,7 @@ pub enum Subcommand {
     Test,
     Bench,
     Deb,
+    Clippy,
 }
 
 impl Subcommand {
@@ -43,6 +44,7 @@ impl<'a> From<&'a str> for Subcommand {
             "test" => Subcommand::Test,
             "bench" => Subcommand::Bench,
             "deb" => Subcommand::Deb,
+            "clippy" => Subcommand::Clippy,
             _ => Subcommand::Other,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,8 +246,8 @@ fn run() -> Result<ExitStatus> {
 
             if !uses_xargo && !available_targets.is_installed(&target) {
                 rustup::install(&target, &toolchain, verbose)?;
-            } else if !rustup::rust_src_is_installed(verbose)? {
-                rustup::install_rust_src(verbose)?;
+            } else if !rustup::component_is_installed("rust-src", toolchain, verbose)? {
+                rustup::install_component("rust-src", toolchain, verbose)?;
             }
 
             let needs_interpreter = args.subcommand.map(|sc| sc.needs_interpreter()).unwrap_or(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use std::{env, io, process};
 
 use toml::{Parser, Value};
 
-use cargo::Root;
+use cargo::{Root, Subcommand};
 use errors::*;
 use rustc::{TargetList, VersionMetaExt};
 
@@ -248,6 +248,12 @@ fn run() -> Result<ExitStatus> {
                 rustup::install(&target, &toolchain, verbose)?;
             } else if !rustup::component_is_installed("rust-src", toolchain, verbose)? {
                 rustup::install_component("rust-src", toolchain, verbose)?;
+            }
+
+            if args.subcommand.map(|sc| sc == Subcommand::Clippy).unwrap_or(false) {
+                if !rustup::component_is_installed("clippy", toolchain, verbose)? {
+                    rustup::install_component("clippy", toolchain, verbose)?;
+                }
             }
 
             let needs_interpreter = args.subcommand.map(|sc| sc.needs_interpreter()).unwrap_or(false);

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -71,17 +71,17 @@ pub fn install(target: &Target, toolchain: &str, verbose: bool) -> Result<()> {
         .chain_err(|| format!("couldn't install `std` for {}", target))
 }
 
-pub fn install_rust_src(verbose: bool) -> Result<()> {
+pub fn install_component(component: &str, toolchain: &str, verbose: bool) -> Result<()> {
     Command::new("rustup")
-        .args(&["component", "add", "rust-src"])
+        .args(&["component", "add", component, "--toolchain", toolchain])
         .run(verbose)
-        .chain_err(|| format!("couldn't install the `rust-src` component"))
+        .chain_err(|| format!("couldn't install the `{}` component", component))
 }
 
-pub fn rust_src_is_installed(verbose: bool) -> Result<bool> {
+pub fn component_is_installed(component: &str, toolchain: &str, verbose: bool) -> Result<bool> {
     Ok(Command::new("rustup")
-        .args(&["component", "list"])
+        .args(&["component", "list", "--toolchain", toolchain])
         .run_and_get_stdout(verbose)?
         .lines()
-        .any(|l| l.starts_with("rust-src") && l.contains("installed")))
+        .any(|l| l.starts_with(component) && l.contains("installed")))
 }


### PR DESCRIPTION
Automatically install `clippy` for the appropriate toolchain. Also fixes `rust-src` not being installed for the appropriate toolchain on macOS.