### PR TITLE
Support mounting on SELinux

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -153,12 +153,12 @@ pub fn run(target: &Target,
 
     docker
         .args(&["-e", &format!("CROSS_RUNNER={}", runner.unwrap_or_else(|| String::new()))])
-        .args(&["-v", &format!("{}:/xargo", xargo_dir.display())])
-        .args(&["-v", &format!("{}:/cargo", cargo_dir.display())])
+        .args(&["-v", &format!("{}:/xargo:Z", xargo_dir.display())])
+        .args(&["-v", &format!("{}:/cargo:Z", cargo_dir.display())])
         .args(&["-v", "/cargo/bin"]) // Prevent `bin` from being mounted inside the Docker container.
-        .args(&["-v", &format!("{}:/project:ro", root.display())])
-        .args(&["-v", &format!("{}:/rust:ro", sysroot.display())])
-        .args(&["-v", &format!("{}:/target", target_dir.display())])
+        .args(&["-v", &format!("{}:/project:Z,ro", root.display())])
+        .args(&["-v", &format!("{}:/rust:Z,ro", sysroot.display())])
+        .args(&["-v", &format!("{}:/target:Z", target_dir.display())])
         .args(&["-w", "/project"])
         .args(&["-it", &image(toml, target)?])
         .args(&["sh", "-c", &format!("PATH=$PATH:/rust/bin {:?}", cmd)])


### PR DESCRIPTION
This should allow `cross` to work on both non-SELinux enabled systems
and SELinux ones.

I've tested on Fedora 29 for SELinux system.

Fixes #112 that was originally reported from Fedora as well I believe.