### PR TITLE
Stop hard-coding NEON support for armv7-unknown-linux-musleabihf.

### DIFF
--- a/docker/armv7-unknown-linux-musleabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-musleabihf/Dockerfile
@@ -27,7 +27,6 @@ COPY musl.sh /
 RUN bash /musl.sh \
     TARGET=arm-linux-musleabihf \
     "COMMON_CONFIG += --with-arch=armv7-a \
-                      --with-fpu=neon \
                       --with-float=hard \
                       --with-mode=thumb"
 


### PR DESCRIPTION
Fixes #252.

Signed-off-by: Brian Smith <brian@briansmith.org>