### PR TITLE
Check for updates on base image during build

### DIFF
--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -4,6 +4,7 @@ set -ex
 
 run() {
     docker build \
+           --pull \
            -t japaric/$1:${TRAVIS_TAG:-latest} \
            -f docker/${1}/Dockerfile \
            docker

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/dropbear.sh
+++ b/docker/dropbear.sh
@@ -1,7 +1,7 @@
 set -ex
 
 main() {
-    local version=2017.75 \
+    local version=2019.77 \
           td=$(mktemp -d)
 
     local dependencies=(

--- a/docker/dropbear.sh
+++ b/docker/dropbear.sh
@@ -24,7 +24,7 @@ main() {
 
     pushd $td
 
-    curl -L https://matt.ucc.asn.au/dropbear/dropbear-$version.tar.bz2 | \
+    curl -L https://matt.ucc.asn.au/dropbear/releases/dropbear-$version.tar.bz2 | \
         tar --strip-components=1 -xj
 
     # Remove some unwanted message

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -46,7 +46,7 @@ main() {
             kernel=4.19.0-4-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
-            # sid version of dropbear requeries this dependencies
+            # sid version of dropbear requires these dependencies
             deps="libtommath1:ppc64 libtomcrypt1:ppc64 libgmp10:ppc64"
             libssl="libssl1.1"
             ;;
@@ -63,7 +63,7 @@ main() {
             kernel=4.19.0-4-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
-            # sid version of dropbear requeries this dependencies
+            # sid version of dropbear requires these dependencies
             deps="libtommath1:sparc64 libtomcrypt1:sparc64 libgmp10:sparc64"
             libssl="libssl1.1"
             ;;

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -33,21 +33,22 @@ main() {
             ;;
         powerpc)
             # there is no stretch powerpc port, so we use jessie
-            # use a more recent kernel from backports
-            kernel=4.9.0-0.bpo.6-powerpc
+            # use a more recent kernel from jessie-updates
+            kernel=3.16.0-6-powerpc
             debsource="deb http://http.debian.net/debian/ jessie main"
-            debsource="$debsource\ndeb http://http.debian.net/debian/ jessie-backports main"
+            debsource="$debsource\ndeb http://http.debian.net/debian/ jessie-updates main"
             dropbear="dropbear"
             libssl="libssl1.0.0"
             ;;
         powerpc64)
             # there is no stable port
             arch=ppc64
-            kernel=4.19.0-1-powerpc64
+            kernel=4.19.0-4-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
-            # sid version of dropbear requeries this depencendies
+            # sid version of dropbear requeries this dependencies
             deps="libtommath1:ppc64 libtomcrypt1:ppc64 libgmp10:ppc64"
+            libssl="libssl1.1"
             ;;
         powerpc64le)
             arch=ppc64el
@@ -59,11 +60,12 @@ main() {
             ;;
         sparc64)
             # there is no stable port
-            kernel=4.19.0-1-sparc64
+            kernel=4.19.0-4-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports/ unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports/ unstable main"
-            # sid version of dropbear requeries this depencendies
+            # sid version of dropbear requeries this dependencies
             deps="libtommath1:sparc64 libtomcrypt1:sparc64 libgmp10:sparc64"
+            libssl="libssl1.1"
             ;;
         x86_64)
             arch=amd64

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
It is important to keep Docker images up-to date, as upstream images
could have important security fixes, even using the same tag and
version.

When building images, it is possible to pass in a `--pull` flag to check
if the base image has updates, and rebuild as necessary. This feature is
available [since 2014], and will still retain the image cache if there are
no updates on the base image.

Travis might need updated Docker version. It is documented how to update it on their docs if it becomes necessary.

[since 2014]: https://github.com/moby/moby/pull/9281