### PR TITLE
Update dockerfiles to never versions of ubuntu

### DIFF
--- a/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Some packages will not build unless never versions of ubuntu is used as a base, due to bugs in old compilators and libs