### PR TITLE
Update Ubuntu version for {x86_64, i686}-unknown-linux-gnu docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ worst, "hang" (never terminate).
 | `i686-linux-android` [5]             | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
 | `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2p  |     | N/A   |        |
-| `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | 1.0.2p  | ✓   | N/A   |   ✓    |
+| `i686-unknown-linux-gnu`             | 2.23   | 5.4.0   | 1.0.2g  | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.20 | 6.3.0   | 1.0.2p  |     | N/A   |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
 | `mips-unknown-linux-musl`            | 1.1.20 | 6.3.0   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
@@ -233,7 +233,7 @@ worst, "hang" (never terminate).
 | `x86_64-sun-solaris` [1]             | 2.11   | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
 | `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
 | `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2p  |     | N/A   |        |
-| `x86_64-unknown-linux-gnu`           | 2.15   | 4.6.2   | 1.0.2p  | ✓   | N/A   |   ✓    |
+| `x86_64-unknown-linux-gnu`           | 2.23   | 5.4.0   | 1.0.2g  | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-linux-musl`          | 1.1.20 | 6.3.0   | 1.0.2p  |     | N/A   |   ✓    |
 | `x86_64-unknown-netbsd`[1]           | 7.0    | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
 

--- a/docker/dropbear.sh
+++ b/docker/dropbear.sh
@@ -24,7 +24,7 @@ main() {
 
     pushd $td
 
-    curl -L https://matt.ucc.asn.au/dropbear/dropbear-$version.tar.bz2 | \
+    curl -L https://matt.ucc.asn.au/dropbear/releases/dropbear-$version.tar.bz2 | \
         tar --strip-components=1 -xj
 
     # Remove some unwanted message

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This should solve `svd2rust` CI build issues.

Also Rust uses Ubuntu 16.04 in [`x86_64-gnu-distcheck`](https://github.com/rust-lang/rust/blob/548add7f61bfcbe3bea3f5ccefb53c84da8fefe4/src/ci/docker/x86_64-gnu-distcheck/Dockerfile) Docker image.