### PR TITLE
WIP: Add clang & ssl

### DIFF
--- a/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -15,7 +15,12 @@ RUN apt-get update && \
     autoconf \
     make \
     file \
-    binutils
+    binutils \
+    openssl \
+    libssl-dev \
+    llvm-dev \
+    libclang-dev \
+    clang
 
 COPY xargo.sh /
 RUN bash /xargo.sh


### PR DESCRIPTION
I"m trying to build my project using `trust` (and thus `cross`) and after much investigation: it seems like I need clang and ( maybe, but I'm not sure) ssl-dev in cross containers. It's really common requirements to need `clang` in Rust projects, unfortunately. I guess ssl is probably already installed anyway, but I guess it doesn't hurt to make it explicit.

Would a PR of this form be accepted? If so I can go over all other targets and make similiar modifications. If there's something to fix, please tell me now, before I copy it over 20 or so times. Thanks!