### PR TITLE
 Improve caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,22 +116,6 @@ deploy:
       condition: $TRAVIS_OS_NAME = linux
       branch: master
 
-before_install:
-  - |
-    if [ $TRAVIS_OS_NAME = linux ]; then
-      docker load --input "$HOME/docker/$TARGET.tar" || true
-    fi
-
-before_cache:
-  - |
-    if [ $TRAVIS_OS_NAME = linux ]; then
-      docker save "rustembedded/cross:$TARGET" --output "$HOME/docker/$TARGET.tar"
-    fi
-
-cache:
-  directories:
-    - $HOME/docker
-
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,21 +116,21 @@ deploy:
       condition: $TRAVIS_OS_NAME = linux
       branch: master
 
+before_install:
+  - |
+    if [ $TRAVIS_OS_NAME = linux ]; then
+      docker load --input "$HOME/docker/$TARGET.tar" || true
+    fi
+
 before_cache:
-  - test $TRAVIS_OS_NAME = osx ||
-    docker history -q "rustembedded/cross:$TARGET" |
-    grep -v \<missing\> |
-    xargs docker save |
-    gzip > $HOME/docker/$TARGET.tar.gz
+  - |
+    if [ $TRAVIS_OS_NAME = linux ]; then
+      docker save "rustembedded/cross:$TARGET" --output "$HOME/docker/$TARGET.tar"
+    fi
 
 cache:
   directories:
     - $HOME/docker
-
-# restore the cache
-before_install:
-  - test $TRAVIS_OS_NAME = osx ||
-    zcat $HOME/docker/$TARGET.tar.gz | docker load || true
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services:
   - docker
 sudo: required
 
+cache: cargo
+
 matrix:
   include:
     # Linux

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,20 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
 cd docker
 
 run() {
-    docker build \
-           -t "rustembedded/cross:${1}" \
-           -f "Dockerfile.${1}" \
-           .
+  local dockerfile="Dockerfile.${1}"
+  local image="rustembedded/cross:${1}"
+
+  time docker pull "${image}" || true
+  time docker build --pull --cache-from "${image}" -t "${image}" -f "${dockerfile}" .
 }
 
-if [ -z $1 ]; then
-    for t in Dockerfile.*; do
-        run "${t##Dockerfile.}"
-    done
+if [ -z "${1}" ]; then
+  for t in Dockerfile.*; do
+    run "${t##Dockerfile.}"
+  done
 else
-    run $1
+  run "${1}"
 fi

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -8,8 +8,8 @@ run() {
   local dockerfile="Dockerfile.${1}"
   local image="rustembedded/cross:${1}"
 
-  time docker pull "${image}" || true
-  time docker build --pull --cache-from "${image}" -t "${image}" -f "${dockerfile}" .
+  docker pull "${image}" || true
+  docker build --pull --cache-from "${image}" -t "${image}" -f "${dockerfile}" .
 }
 
 if [ -z "${1}" ]; then

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 use std::{env, fs};


### PR DESCRIPTION
Pulling an image from Docker Hub is approximately twice as fast as extracting it from the Travis cache.