### PR TITLE
Automatically download `-apple-ios` components on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,25 +189,26 @@ unit tests spawns threads, then it's more likely to fail or, worst, never
 terminate.
 
 | Target                               |  libc  |   GCC   | OpenSSL | C++ | QEMU  | `test` |
-|--------------------------------------|--------|---------|---------|:---:|-------|:------:|
-| `aarch64-linux-android` [5]          | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
+|--------------------------------------|-------:|--------:|--------:|:---:|------:|:------:|
+| `*-apple-ios` [1]                    | N/A    | N/A     | N/A     | N/A | N/A   |   ✓    |
+| `aarch64-linux-android` [2]          | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `aarch64-unknown-linux-gnu`          | 2.19   | 4.8.2   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
 | `aarch64-unknown-linux-musl`         | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
-| `arm-linux-androideabi` [5]          | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
+| `arm-linux-androideabi` [2]          | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
 | `arm-unknown-linux-gnueabihf`        | 2.27   | 7.3.0   | 1.0.2p  | ✓   | 2.10  |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabihf`       | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
 | `armv5te-unknown-linux-musleabi`     | 1.1.20 | 6.3.0   |  N/A    |     | 2.8.0 |   ✓    |
-| `armv7-linux-androideabi` [5]        | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
+| `armv7-linux-androideabi` [2]        | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `armv7-unknown-linux-gnueabihf`      | 2.15   | 4.6.2   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
 | `armv7-unknown-linux-musleabihf`     | 1.1.20 | 6.3.0   | 1.0.2p  |     | 2.8.0 |   ✓    |
-| `asmjs-unknown-emscripten` [4]       | 1.1.20 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
+| `asmjs-unknown-emscripten` [3]       | 1.1.20 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-musl`            | 1.1.20 | 6.3.0   | 1.0.2p  |     | N/A   |   ✓    |
-| `i686-linux-android` [5]             | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
+| `i686-linux-android` [2]             | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
-| `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2p  |     | N/A   |        |
+| `i686-unknown-freebsd` [4]           | 10.2   | 5.3.0   | 1.0.2p  |     | N/A   |        |
 | `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.20 | 6.3.0   | 1.0.2p  |     | N/A   |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
@@ -220,37 +221,39 @@ terminate.
 | `powerpc64-unknown-linux-gnu`        | 2.19   | 4.8.2   | 1.0.2p  | ✓   | 2.7.1 |   ✓    |
 | `powerpc64le-unknown-linux-gnu`      | 2.19   | 4.8.2   | 1.0.2p  | ✓   | 2.7.1 |   ✓    |
 | `s390x-unknown-linux-gnu`            | 2.23   | 5.3.1   | 1.0.2p  | ✓   | 2.8.0 |        |
-| `sparc64-unknown-linux-gnu` [2]      | 2.23   | 5.3.1   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
-| `sparcv9-sun-solaris` [1]            | 2.11   | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
-| `thumbv6m-none-eabi` [3]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
-| `thumbv7em-none-eabi` [3]            | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
-| `thumbv7em-none-eabihf` [3]          | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
-| `thumbv7m-none-eabi` [3]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
-| `wasm32-unknown-emscripten` [4]      | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
-| `x86_64-linux-android` [5]           | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
+| `sparc64-unknown-linux-gnu` [5]      | 2.23   | 5.3.1   | 1.0.2p  | ✓   | 2.8.0 |   ✓    |
+| `sparcv9-sun-solaris` [4]            | 2.11   | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
+| `thumbv6m-none-eabi` [6]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
+| `thumbv7em-none-eabi` [6]            | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
+| `thumbv7em-none-eabihf` [6]          | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
+| `thumbv7m-none-eabi` [6]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
+| `wasm32-unknown-emscripten` [3]      | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
+| `x86_64-linux-android` [2]           | N/A    | 4.9     | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `x86_64-pc-windows-gnu`              | N/A    | 7.3.0   | N/A     | ✓   | N/A   |   ✓    |
-| `x86_64-sun-solaris` [1]             | 2.11   | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
-| `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
-| `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2p  |     | N/A   |        |
+| `x86_64-sun-solaris` [4]             | 2.11   | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
+| `x86_64-unknown-dragonfly` [4] [5]   | 4.6.0  | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
+| `x86_64-unknown-freebsd` [4]         | 10.2   | 5.3.0   | 1.0.2p  |     | N/A   |        |
 | `x86_64-unknown-linux-gnu`           | 2.15   | 4.6.2   | 1.0.2p  | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-linux-musl`          | 1.1.20 | 6.3.0   | 1.0.2p  |     | N/A   |   ✓    |
-| `x86_64-unknown-netbsd`[1]           | 7.0    | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
+| `x86_64-unknown-netbsd` [4]          | 7.0    | 5.3.0   | 1.0.2p  | ✓   | N/A   |        |
 
-[1] For *BSD and Solaris targets, the libc column indicates the OS release version from
-where libc was extracted.
+[1] iOS cross compilation is supported on macOS hosts.
 
-[2] No `std` component available as of 2017-01-10
-
-[3] libc = newlib
-
-[4] libc = musl, gcc = emcc; Some projects that use libc may fail due to wrong
-    definitions (will be fixed by https://github.com/rust-lang/libc/pull/610)
-
-[5] Only works with native tests, that is, tests that do not depends on the
+[2] Only works with native tests, that is, tests that do not depends on the
     Android Runtime. For i686 some tests may fails with the error `assertion
     failed: signal(libc::SIGPIPE, libc::SIG_IGN) != libc::SIG_ERR`, see
     [issue #140](https://github.com/rust-embedded/cross/issues/140) for more
     information.
+
+[3] libc = musl, gcc = emcc; Some projects that use libc may fail due to wrong
+    definitions (will be fixed by https://github.com/rust-lang/libc/pull/610)
+
+[4] For *BSD and Solaris targets, the libc column indicates the OS release version
+    from which libc was extracted.
+
+[5] No `std` component available as of 2017-01-10
+
+[6] libc = newlib
 
 ## Debugging
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ impl Host {
     /// `target == None` means `target == host`
     fn is_supported(&self, target: Option<&Target>) -> bool {
         if *self == Host::X86_64AppleDarwin {
-            target.map(|t| t.triple() == "i686-apple-darwin" || t.needs_docker()).unwrap_or(false)
+            target.map(|t| t.is_apple() || t.needs_docker()).unwrap_or(false)
         } else if *self == Host::X86_64UnknownLinuxGnu {
             target.map(|t| t.needs_docker()).unwrap_or(true)
         } else if *self == Host::X86_64PcWindowsMsvc {
@@ -109,6 +109,10 @@ impl Target {
             Target::BuiltIn{ref triple} => triple,
             Target::Custom{ref triple} => triple,
         }
+    }
+
+    fn is_apple(&self) -> bool {
+        self.triple().contains("apple")
     }
 
     fn is_bare_metal(&self) -> bool {


### PR DESCRIPTION
Closes https://github.com/rust-embedded/cross/issues/148.