### PR TITLE
Patch for breaking 32-bit float conversions on ppc (#313).

### DIFF
--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -1,7 +1,18 @@
+#!/usr/bin/env bash
+
 set -ex
 
 main() {
     local version=4.1.0
+
+    # Qemu versions 3.10.0 and above break 32-bit float conversions
+    # on powerpc, powerpc64, and powerpc64le. Last known working version
+    # is 3.0.1.
+    # Upstream Issue:
+    #   https://bugs.launchpad.net/qemu/+bug/1821444
+    if [[ $1 == ppc* ]]; then
+        version=3.0.1
+    fi
 
     local arch=$1 \
           os=$2 \


### PR DESCRIPTION
Use qemu-3.0.1 for all powerpc architectures, and 4.1.0 for everything else.

Note: @reitermarkus, this requires bash for the scripting language, not shell, which the Dockerfiles currently use. I'm not sure if this is a deal-breaker.

Closes https://github.com/rust-embedded/cross/issues/313.