### PR TITLE
updated kernel version from 4.9.0-8 -> 4.9.0-11

### DIFF
--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -3,7 +3,7 @@ set -ex
 main() {
     # arch in the rust target
     local arch=$1 \
-          kversion=4.9.0-8
+          kversion=4.9.0-11
 
     local debsource="deb http://http.debian.net/debian/ stretch main"
     debsource="$debsource\ndeb http://security.debian.org/ stretch/updates main"


### PR DESCRIPTION
Fixes #330 

There seems to be no 4.9.0-8 available on [debian packages](https://packages.debian.org/search?keywords=kernel-image).