### PR TITLE
Update emscripten to 1.38.46-upstream

### DIFF
--- a/docker/emscripten.sh
+++ b/docker/emscripten.sh
@@ -19,24 +19,19 @@ main() {
     done
 
     cd /
-    curl -L https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz | \
-        tar -xz
-    cd /emsdk-portable
+    git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
 
     export HOME=/emsdk-portable/
 
-    ./emsdk update
-    ./emsdk install sdk-1.38.15-64bit
-    ./emsdk activate sdk-1.38.15-64bit
+    ./emsdk install 1.38.46-upstream
+    ./emsdk activate 1.38.46-upstream
 
     # Compile and cache libc
     source ./emsdk_env.sh
     echo "main(){}" > a.c
     emcc a.c
-    emcc -s BINARYEN=1 a.c
     echo -e "#include <iostream>\n void hello(){ std::cout << std::endl; }" > a.cpp
     emcc a.cpp
-    emcc -s BINARYEN=1 a.cpp
     rm -f a.*
 
     # Make emsdk usable by any user

--- a/docker/emscripten.sh
+++ b/docker/emscripten.sh
@@ -20,6 +20,7 @@ main() {
 
     cd /
     git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
+    cd /emsdk-portable
 
     export HOME=/emsdk-portable/
 


### PR DESCRIPTION
Rust updated its emscripten version again to a version that uses the upstream LLVM wasm backend that the other Rust wasm targets are also using. cross' docker has been updated accordingly: https://github.com/rust-lang/rust/pull/63649/files#diff-3334ef4d3e22f40ded09f2045806021f