### PR TITLE
Fix Android’s CPU features

### DIFF
--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -22,7 +22,7 @@ RUN cp /android-ndk/sysroot/usr/lib/libz.so /system/lib/
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
-    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="qemu-x86_64 -cpu Penryn" \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="qemu-x86_64 -cpu qemu64,+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt" \
     CC_x86_64_linux_android=x86_64-linux-android-gcc \
     CXX_x86_64_linux_android=x86_64-linux-android-g++ \
     DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -49,8 +49,8 @@ main() {
         powerpc64)
             # there is no stable port
             arch=ppc64
-            # https://packages.debian.org/de/sid/linux-image-powerpc64
-            kernel=5.2.0-3-powerpc64
+            # https://packages.debian.org/en/sid/linux-image-powerpc64
+            kernel=5.3.0-1-powerpc64
             debsource="deb http://ftp.ports.debian.org/debian-ports unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports unstable main"
             # sid version of dropbear requires these dependencies
@@ -66,8 +66,8 @@ main() {
             ;;
         sparc64)
             # there is no stable port
-            # https://packages.debian.org/de/sid/linux-image-sparc64
-            kernel=5.2.0-3-sparc64
+            # https://packages.debian.org/en/sid/linux-image-sparc64
+            kernel=5.3.0-1-sparc64
             debsource="deb http://ftp.ports.debian.org/debian-ports unreleased main"
             debsource="$debsource\ndeb http://ftp.ports.debian.org/debian-ports unstable main"
             # sid version of dropbear requires these dependencies


### PR DESCRIPTION
The Rust Android target uses CPU features such as +popcnt and +sse4.2 which
are not available on Penryn. List the used CPU exactly the same way as
it is listed in the Rust target [here](https://github.com/rust-lang/rust/blob/master/src/librustc_target/spec/x86_64_linux_android.rs#L7).

Please publish an updated docker image sooner rather than later.