### PR TITLE
Monkey Patch for support target_dir.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,12 +8,14 @@ pub struct Args {
     pub all: Vec<String>,
     pub subcommand: Option<Subcommand>,
     pub target: Option<Target>,
+    pub target_dir: Option<String>,
 }
 
 pub fn parse(target_list: &TargetList) -> Args {
-    let all: Vec<_> = env::args().skip(1).collect();
+    let mut all: Vec<_> = env::args().skip(1).collect();
 
     let mut target = None;
+    let mut target_dir = None;
     let mut sc = None;
 
     {
@@ -29,15 +31,30 @@ pub fn parse(target_list: &TargetList) -> Args {
                 target = arg.splitn(2, '=')
                     .nth(1)
                     .map(|s| Target::from(&*s, target_list))
+            } else if arg == "--target-dir" {
+                target_dir = args.next().map(|s| s.clone());
+            } else if arg.starts_with("--target-dir=") {
+                target_dir = arg.splitn(2, '=').nth(1).map(|s| s.to_owned())
             } else if !arg.starts_with('-') && sc.is_none() {
                 sc = Some(Subcommand::from(&**arg));
             }
         }
     }
 
+    // delete target-dir from args.all
+    if let Some(ind) = all.iter().position(|x| x=="--target-dir") {
+      all[ind]=String::new();
+      all[ind+1]=String::new();
+    }
+    if let Some(ind) = all.iter().position(|x| x.starts_with("--target-dir=")) {
+      all[ind]=String::new();
+    }
+    all = all.into_iter().filter(|x| !x.is_empty()).collect();
+
     Args {
         all: all,
         subcommand: sc,
         target: target,
+        target_dir: target_dir,
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -70,6 +70,7 @@ pub fn register(target: &Target, verbose: bool) -> Result<()> {
 }
 
 pub fn run(target: &Target,
+           target_dir: Option<&str>,
            args: &[String],
            root: &Root,
            toml: Option<&Toml>,
@@ -83,7 +84,7 @@ pub fn run(target: &Target,
     let xargo_dir = env::var_os("XARGO_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir.join(".xargo"));
-    let target_dir = root.join("target");
+    let target_dir = target_dir.map(|s| PathBuf::from(s)).unwrap_or(root.join("target"));
 
     // create the directories we are going to mount before we mount them,
     // otherwise `docker` will create them but they will be owned by `root`

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,6 +280,7 @@ fn run() -> Result<ExitStatus> {
                 }
 
                 return docker::run(&target,
+                                   args.target_dir.as_ref().map(|s| &s[..]),
                                    &args.all,
                                    &root,
                                    toml.as_ref(),


### PR DESCRIPTION
This is just an adhoc solution for issue #272
Possble improvement: read `.cargo/config` to get target-dir.