### PR TITLE
Adding support for Podman

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,14 +71,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "home"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,7 +160,6 @@ name = "which"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -199,7 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c315e106bd6f83f026a20ddaeef2706782e490db1dcdd37caad38a0e895b3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -16,7 +16,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -26,7 +26,7 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -52,11 +52,12 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -67,6 +68,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -85,7 +94,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -96,7 +105,7 @@ dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -155,6 +164,15 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "which"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +199,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c315e106bd6f83f026a20ddaeef2706782e490db1dcdd37caad38a0e895b3"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -194,6 +213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2.18"
 rustc_version = "0.2"
 semver = "0.9"
 toml = "0.5"
-which = "3.1.0"
+which = { version = "3.1.0", default_features = false }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ libc = "0.2.18"
 rustc_version = "0.2"
 semver = "0.9"
 toml = "0.5"
+which = "3.1.0"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.15"

--- a/README.md
+++ b/README.md
@@ -36,14 +36,18 @@ This project is developed and maintained by the [Tools team][team].
 
 - [rustup](https://rustup.rs/)
 
+- A Linux kernel with [binfmt_misc] support is required for cross testing.
+
+[binfmt_misc]: https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+
+One of these container engines is required:
+
 - [Docker](https://www.docker.com/). Note that on Linux non-sudo users need to be in the
   `docker` group. Read the official [post-installation steps][post].
 
 [post]: https://docs.docker.com/install/linux/linux-postinstall/
 
-- A Linux kernel with [binfmt_misc] support is required for cross testing.
-
-[binfmt_misc]: https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+- [Podman](https://podman.io). Requires version 1.6.3 or later.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ $ cross rustc --target powerpc-unknown-linux-gnu --release -- -C lto
 You can place a `Cross.toml` file in the root of your Cargo project to tweak
 `cross`'s behavior:
 
+### Using an Alternative Container Engine
+
+`cross` allows the user to specify the container engine they would like to use.
+Currently, only Docker and Podman are supported. `cross` will default to using
+Docker. For other container engines, you can use the
+`target.{{TARGET}}.container_engine` field in `Cross.toml`:
+
+``` toml
+[target.aarch64-unknown-linux-gnu]
+container_engine = "podman"
+```
+
 ### Custom Docker images
 
 `cross` provides default Docker images for the targets listed below. However, it

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This project is developed and maintained by the [Tools team][team].
 One of these container engines is required:
 
 - [Docker](https://www.docker.com/). Note that on Linux non-sudo users need to be in the
-  `docker` group. Read the official [post-installation steps][post].
+  `docker` group. Read the official [post-installation steps][post]. Requires version
+  1.24 or later.
 
 [post]: https://docs.docker.com/install/linux/linux-postinstall/
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This project is developed and maintained by the [Tools team][team].
 
 [binfmt_misc]: https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
 
-One of these container engines is required:
+One of these container engines is required. If both are installed, `cross` will
+default to `docker`.
 
 - [Docker](https://www.docker.com/). Note that on Linux non-sudo users need to be in the
   `docker` group. Read the official [post-installation steps][post]. Requires version
@@ -81,18 +82,6 @@ $ cross rustc --target powerpc-unknown-linux-gnu --release -- -C lto
 
 You can place a `Cross.toml` file in the root of your Cargo project to tweak
 `cross`'s behavior:
-
-### Using an Alternative Container Engine
-
-`cross` allows the user to specify the container engine they would like to use.
-Currently, only Docker and Podman are supported. `cross` will default to using
-Docker. For other container engines, you can use the
-`target.{{TARGET}}.container_engine` field in `Cross.toml`:
-
-``` toml
-[target.aarch64-unknown-linux-gnu]
-container_engine = "podman"
-```
 
 ### Custom Docker images
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -17,8 +17,6 @@ const DOCKER: &str = "docker";
 pub fn docker_command(container_engine: &str, subcommand: &str) -> Command {
     let mut docker = Command::new(container_engine);
     docker.arg(subcommand);
-
-    // We always add the `---userns host` flag for compatibility with Podman.
     docker.args(&["--userns", "host"]);
     docker
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -146,15 +146,9 @@ pub fn run(target: &Target,
     docker
         .args(&["-e", &format!("CROSS_RUNNER={}", runner.unwrap_or_else(|| String::new()))])
         .args(&["-v", &format!("{}:/xargo:Z", xargo_dir.display())])
-        .args(&["-v", &format!("{}:/cargo:Z", cargo_dir.display())]);
-
-    // Prevent `bin` from being mounted inside the Docker container. This is
-    // not required for Podman.
-    if container_engine == DOCKER {
-        docker.args(&["-v", "/cargo/bin"]);
-    }
-
-    docker
+        .args(&["-v", &format!("{}:/cargo:Z", cargo_dir.display())])
+        // Prevent `bin` from being mounted inside the Docker container.
+        .args(&["-v", "/cargo/bin"])
         .args(&["-v", &format!("{}:/project:Z,ro", root.display())])
         .args(&["-v", &format!("{}:/rust:Z,ro", sysroot.display())])
         .args(&["-v", &format!("{}:/target:Z", target_dir.display())])

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,5 +5,6 @@ use error_chain::error_chain;
 error_chain! {
   foreign_links {
     Io(std::io::Error);
+    Which(which::Error);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ fn run() -> Result<ExitStatus> {
                     needs_interpreter &&
                     target.needs_interpreter() &&
                     !interpreter::is_registered(&target)? {
-                        docker::register(&target, verbose)?
+                        docker::register(&target, toml.as_ref(), verbose)?
                 }
 
                 return docker::run(&target,
@@ -328,6 +328,27 @@ impl Toml {
             Ok(None)
         }
     }
+
+        /// Returns the `target.{}.container_engine` part of `Cross.toml`
+    pub fn container_engine(&self, target: &Target) -> Result<Option<String>> {
+        let triple = target.triple();
+
+        if let Some(value) = self
+            .table
+            .get("target")
+            .and_then(|t| t.get(triple))
+            .and_then(|t| t.get("container_engine"))
+        {
+            let value = value
+                .as_str()
+                .ok_or_else(|| format!("target.{}.container_engine must be a string", triple))?
+                .to_string();
+            Ok(Some(value))
+        } else {
+            Ok(None)
+        }
+    }
+
 
     /// Returns the `build.image` or the `target.{}.xargo` part of `Cross.toml`
     pub fn xargo(&self, target: &Target) -> Result<Option<bool>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,7 +329,7 @@ impl Toml {
         }
     }
 
-        /// Returns the `target.{}.container_engine` part of `Cross.toml`
+    /// Returns the `target.{}.container_engine` part of `Cross.toml`
     pub fn container_engine(&self, target: &Target) -> Result<Option<String>> {
         let triple = target.triple();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ fn run() -> Result<ExitStatus> {
                     needs_interpreter &&
                     target.needs_interpreter() &&
                     !interpreter::is_registered(&target)? {
-                        docker::register(&target, toml.as_ref(), verbose)?
+                        docker::register(&target, verbose)?
                 }
 
                 return docker::run(&target,
@@ -328,27 +328,6 @@ impl Toml {
             Ok(None)
         }
     }
-
-    /// Returns the `target.{}.container_engine` part of `Cross.toml`
-    pub fn container_engine(&self, target: &Target) -> Result<Option<String>> {
-        let triple = target.triple();
-
-        if let Some(value) = self
-            .table
-            .get("target")
-            .and_then(|t| t.get(triple))
-            .and_then(|t| t.get("container_engine"))
-        {
-            let value = value
-                .as_str()
-                .ok_or_else(|| format!("target.{}.container_engine must be a string", triple))?
-                .to_string();
-            Ok(Some(value))
-        } else {
-            Ok(None)
-        }
-    }
-
 
     /// Returns the `build.image` or the `target.{}.xargo` part of `Cross.toml`
     pub fn xargo(&self, target: &Target) -> Result<Option<bool>> {


### PR DESCRIPTION
- Via the new container_engine parameter in Cross.toml, the user can now
  specify whether they want to use Podman or Docker.
- Several changes to src/docker.rs to pass in different options based on whether
  docker or podman is being used. This also mandates the use of `--userns host`
  which does require bumping the minimum Docker version.
- Updates to the code base based on rustfmt and clippy recommendations.