### PR TITLE
Allow writing `Cargo.toml` in project directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,6 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
   work because `cross` use docker containers only mounts the Cargo project so
   the container doesn't have access to the rest of the filesystem.
 
-- `cross` will mount the Cargo project as READ ONLY. Thus, if any crate attempts
-  to modify its “source”, the build will fail. Well behaved crates should only
-  ever write to `$OUT_DIR` and never modify `$CARGO_MANIFEST_DIR` though.
-
 ## License
 
 Licensed under either of

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -78,17 +78,7 @@ pub fn run(target: &Target,
     };
     cmd.args(args);
 
-    // We create/regenerate the lockfile on the host system because the Docker
-    // container doesn't have write access to the root of the Cargo project
-    let cargo_toml = root.join("Cargo.toml");
-
     let runner = None;
-
-    Command::new("cargo").args(&["fetch",
-                "--manifest-path",
-                &cargo_toml.display().to_string()])
-        .run(verbose)
-        .chain_err(|| "couldn't generate Cargo.lock")?;
 
     let mut docker = docker_command("run")?;
 
@@ -144,7 +134,7 @@ pub fn run(target: &Target,
         .args(&["-v", &format!("{}:/cargo:Z", cargo_dir.display())])
         // Prevent `bin` from being mounted inside the Docker container.
         .args(&["-v", "/cargo/bin"])
-        .args(&["-v", &format!("{}:/project:Z,ro", root.display())])
+        .args(&["-v", &format!("{}:/project:Z", root.display())])
         .args(&["-v", &format!("{}:/rust:Z,ro", sysroot.display())])
         .args(&["-v", &format!("{}:/target:Z", target_dir.display())])
         .args(&["-w", "/project"]);


### PR DESCRIPTION
The project directory was previously deliberately mounted as read-only since “well behaved crates should only ever write to `$OUT_DIR` and never modify `$CARGO_MANIFEST_DIR`”.  That however, breaks the `--locked` flag and is not worth the additional complexity.

Fixes https://github.com/rust-embedded/cross/issues/346.