### PR TITLE
Configure ports.ubuntu.com in APT sources

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -3,6 +3,12 @@
 set -x
 set -euo pipefail
 
+# For architectures except amd64 and i386, look for packages on ports.ubuntu.com instead.
+# This is important if you enable additional architectures so you can install libraries to cross-compile against.
+# Look for 'dpkg --add-architecture' in the README for more details.
+sed 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch-=amd64,i386] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g' /etc/apt/sources.list > /etc/apt/sources.list.d/ports.list
+sed -i 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch=amd64,i386] http:\/\/\1.archive.ubuntu.com\/ubuntu\//g' /etc/apt/sources.list
+
 apt-get update
 
 apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The recommendation given in the README to use `dpkg --add-architecture` to install additional libraries doesn't actually work because the packages for most architectures are on a different server. 

This change configures the APT sources so it knows where every architecture is located, and the recommendation given in the README works. It took me a while to figure out that there is a separate server for these architectures, and exactly how to configure APT to not query the normal servers for  architectures which are hosted by the 'ports' server (since that causes errors). It could be added to the README instead, but to me it seems reasonable to preconfigure it.

The package locations should be accurate for all current Ubuntu releases, although I have only tested it with 16.04 and just looked at the repository content for later versions.

I have tested these two shell commands in a docker image based on the official cross docker images. I think this would be the best place to put them so that all cross users can benefit from them, and they *should* work here but I've not tried to build an image.