### PR TITLE
docker: define PKG_CONFIG_ALLOW_CROSS

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -101,6 +101,8 @@ pub fn run(target: &Target,
         }
     }
 
+    docker.args(&["-e", "PKG_CONFIG_ALLOW_CROSS=1"]);
+
     docker.arg("--rm");
 
     // We need to specify the user for Docker, but not for Podman.


### PR DESCRIPTION
The PKG_CONFIG_ALLOW_CROSS env variable is required to cross compile
various crates such as openssl.

Fix #383