### PR TITLE
Docker in docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,6 +88,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -124,6 +130,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shell-escape"
@@ -201,14 +222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
 "checksum hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
 "checksum home 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum shell-escape 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ semver = "0.9"
 toml = "0.5"
 which = { version = "3.1.0", default_features = false }
 shell-escape = "0.1.4"
+serde_json = "1.0.48"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.15"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,9 @@ jobs:
       - bash: echo "##vso[task.setvariable variable=TAG]${BUILD_SOURCEBRANCH##refs/tags/}"
         displayName: Set TAG Variable
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+      - bash: cargo test 
+        displayName: Run unit tests
+        timeoutInMinutes: 5
       - bash: ./build-docker-image.sh "${TARGET}"
         displayName: Build Docker Image
         timeoutInMinutes: 360

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,8 @@ fn run() -> Result<ExitStatus> {
                                    toml.as_ref(),
                                    uses_xargo,
                                    &sysroot,
-                                   verbose);
+                                   verbose,
+                                   args.docker_in_docker);
             }
         }
     }


### PR DESCRIPTION
When using docker-in-docker, for example in dev or CI containers, one
normally gives access to the host docker environment to the parent container.
If the container spins up another child container, and wishes
to share a directory, one needs to compute the correct paths from
view of the host system.

### How it Works
If the environment variable `CROSS_DOCKER_IN_DOCKER=true`, we call 
`docker inspect $HOSTNAME`, to learn about details of the current container.
The `Mounts` field contains information about all mounts from the host
into the current container. The `GraphDriver` field gives us information
about the storage driver and the location of the contains root directory on the host system. Based on these information we compute
a table of all container mounts (`source->destination`).

When starting a child container we adapt all paths to be mounted, that have
a prefix in the table, to start with source. For example when mounting a
dev containers `/usr/local/cargo` directory, we will actually mount
`/var/lib/docker/overlay2/<parent container id>/merged/usr/local/cargo`.

If the project itself is mounted into the parent container, we will not
use the overlay directory, but find the project path on the host system.

### Limitations 

Finding the mount point for the containers root directory is only
implemented for the overlayfs2 storage driver.

In order to access the parent containers rust setup, the child container
mounts the parents overlayfs. The parent must not be stopped before the
child container, as the overlayfs can not be unmounted correctly by
docker if the child container still accesses it.