### PR TITLE
Remove support for `i686-apple-darwin`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Removed CI testing for `i686-apple-darwin`.
+
 ## [v0.2.0] - 2020-02-22
 
 - Removed OpenSSL from all images.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,6 @@ jobs:
         armv7-linux-androideabi:         { TARGET: armv7-linux-androideabi,         CPP: 1,           STD: 1, RUN: 1 }
         i686-linux-android:              { TARGET: i686-linux-android,              CPP: 1,           STD: 1, RUN: 1 }
         x86_64-linux-android:            { TARGET: x86_64-linux-android,            CPP: 1,           STD: 1, RUN: 1 }
-        i686-apple-darwin:               { TARGET: i686-apple-darwin,               CPP: 1, DYLIB: 1, STD: 1,                   RUN: 1, VM_IMAGE: macOS-10.13 }
         x86_64-apple-darwin:             { TARGET: x86_64-apple-darwin,             CPP: 1, DYLIB: 1, STD: 1,                   RUN: 1, VM_IMAGE: macOS-latest, DEPLOY: 1 }
         x86_64-pc-windows-gnu:           { TARGET: x86_64-pc-windows-gnu,           CPP: 1,           STD: 1,                   RUN: 1 }
         # `cargo build` fails with undefined symbols (https://github.com/rust-lang/rust/issues/32859) on `i686-pc-windows-gnu`.


### PR DESCRIPTION
The High Sierra image on Azure Pipelines is deprecated and testing doesn't work on Mojave.