### PR TITLE
Bump up ubuntu (and accompanying gcc) and musl

### DIFF
--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.10
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -38,7 +38,7 @@ main() {
     local td=$(mktemp -d)
 
     pushd $td
-    curl -L https://github.com/richfelker/musl-cross-make/archive/v0.9.8.tar.gz | \
+    curl -L https://github.com/richfelker/musl-cross-make/archive/v0.9.9.tar.gz | \
         tar --strip-components=1 -xz
 
     hide_output make install -j$(nproc) \


### PR DESCRIPTION
Try to avoid/fix issues like this one with openssl when compiling stuff with musl:

https://github.com/openssl/openssl/issues/7207

Hopefully fixing https://github.com/rust-embedded/cross/issues/391 and perhaps other issues...

~~Bump up GCC version while I'm at it.~~ rolling that back for now... so much breakage because [`musl-cross-make`](https://github.com/richfelker/musl-cross-make) seems to have [fixed versions/assumptions about GCC and others](https://dev.azure.com/rust-embedded/cross/_build/results?buildId=469&view=logs&j=5da8f75e-9c2e-5fcc-a988-a4dc84730531&t=a6fb5e14-f456-51ea-f90a-4d90dbf8b6b6&l=414):

```
(...) make install -j2 GCC_VER=6.4.0 MUSL_VER=1.1.22
```