### PR TITLE
docker: linux-image: add gnupg to local deps

### DIFF
--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -91,6 +91,7 @@ main() {
     local dependencies=(
         cpio
         sharutils
+        gnupg
     )
 
     local purge_list=()


### PR DESCRIPTION
It's needed when generating an image based on Ubuntu 18.04 or Debian
Buster. Adding it makes it easier for users to create such image as they
can just re-use the existing script without having to modify it.
It doesn't matter when building with Ubuntu 16.04 as the package is
already present in the base image so it's just skipped.