### PR TITLE
Add riscv64gc-unknown-linux-gnu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ terminate.
 | `powerpc-unknown-linux-gnu`          | 2.19   | 4.8.2   | ✓   | 3.0.1 |   ✓    |
 | `powerpc64-unknown-linux-gnu`        | 2.19   | 4.8.2   | ✓   | 3.0.1 |   ✓    |
 | `powerpc64le-unknown-linux-gnu`      | 2.19   | 4.8.2   | ✓   | 3.0.1 |   ✓    |
+| `riscv64gc-unknown-linux-gnu`        | 2.27   | 7.5.0   | ✓   | 4.2.0 |   ✓    |
 | `s390x-unknown-linux-gnu`            | 2.23   | 5.3.1   | ✓   | 4.1.0 |        |
 | `sparc64-unknown-linux-gnu` [3]      | 2.23   | 5.3.1   | ✓   | 4.1.0 |   ✓    |
 | `sparcv9-sun-solaris` [4]            | 2.11   | 5.3.0   | ✓   | N/A   |        |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
         powerpc-unknown-linux-gnu:       { TARGET: powerpc-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64-unknown-linux-gnu:     { TARGET: powerpc64-unknown-linux-gnu,     CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64le-unknown-linux-gnu:   { TARGET: powerpc64le-unknown-linux-gnu,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
+        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1 }
         s390x-unknown-linux-gnu:         { TARGET: s390x-unknown-linux-gnu,         CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         sparc64-unknown-linux-gnu:       { TARGET: sparc64-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         x86_64-unknown-linux-gnu:        { TARGET: x86_64-unknown-linux-gnu,        CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: native qemu-user qemu-system, DEPLOY: 1, CRATES_IO_PUBLISH: 1 }

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04
+
+COPY common.sh /
+RUN /common.sh
+
+# COPY cmake.sh /
+# RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get install -y --no-install-recommends \
+    g++-riscv64-linux-gnu \
+    libc6-dev-riscv64-cross
+
+COPY qemu.sh /
+RUN /qemu.sh riscv64
+
+COPY linux-runner /
+
+ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc \
+    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner riscv64" \
+    CC_riscv64gc_unknown_linux_gnu=riscv64-linux-gnu-gcc \
+    CXX_riscv64gc_unknown_linux_gnu=riscv64-linux-gnu-g++ \
+    QEMU_LD_PREFIX=/usr/riscv64-linux-gnu \
+    RUST_TEST_THREADS=1

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -47,6 +47,7 @@ main() {
 
             # archive.debian.org Release files are expired.
             echo "Acquire::Check-Valid-Until false;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
+            echo "APT::Get::AllowUnauthenticated true;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
 
             dropbear="dropbear"
             ;;


### PR DESCRIPTION
rust support for riscv64gc-unknown-linux-gnu [is not yet advertised](https://forge.rust-lang.org/release/platform-support.html), but [is merged](https://github.com/rust-lang/rust/pull/66661).

There are [issues](https://github.com/rust-lang/rust/issues/62117) with riscv64gc-unknown-linux-gnu but it works well enough to build many crates (including rustc).