### PR TITLE
README: use `apt-get --assume-yes` in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.1.16
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
-    apt-get install libfoo:arm64
+    apt-get install --assume-yes libfoo:arm64
 ```
 
 ```

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-aarch64-linux-gnu \
     libc6-dev-arm64-cross
 

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
     libc6-dev-armel-cross && \
     /qemu.sh arm

--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN mkdir /usr/arm-linux-gnueabihf && \
-    apt-get install -y --no-install-recommends curl xz-utils && \
+    apt-get install --assume-yes --no-install-recommends curl xz-utils && \
     cd /usr/arm-linux-gnueabihf && \
     curl -L https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz | \
     tar --strip-components 1 -xJ && \

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
     crossbuild-essential-armel \
     libc6-dev-armel-cross && \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
 

--- a/docker/Dockerfile.asmjs-unknown-emscripten
+++ b/docker/Dockerfile.asmjs-unknown-emscripten
@@ -23,7 +23,7 @@ ENV PATH="${EMSDK}:${EMSDK}/emscripten/sdk:${EMSDK}/llvm/clang/bin:${EMSDK}/node
 
 ENTRYPOINT ["/emsdk_portable/entrypoint"]
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   libxml2 \
   python
 

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -9,5 +9,5 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-multilib

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-multilib
 
 COPY qemu.sh /

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-mips-linux-gnu \
     libc6-dev-mips-cross
 

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-mips64-linux-gnuabi64 \
     libc6-dev-mips64-cross && \
     /qemu.sh mips64

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-mips64el-linux-gnuabi64 \
     libc6-dev-mips64el-cross
 

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-mipsel-linux-gnu \
     libc6-dev-mipsel-cross
 

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-powerpc-linux-gnu \
     libc6-dev-powerpc-cross
 

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64-linux-gnu \
     libc6-dev-ppc64-cross
 

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64le-linux-gnu \
     libc6-dev-ppc64el-cross
 

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-s390x-linux-gnu \
     libc6-dev-s390x-cross
 

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     g++-sparc64-linux-gnu \
     libc6-dev-sparc64-cross
 

--- a/docker/Dockerfile.thumbv6m-none-eabi
+++ b/docker/Dockerfile.thumbv6m-none-eabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.thumbv7em-none-eabi
+++ b/docker/Dockerfile.thumbv7em-none-eabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.thumbv7em-none-eabihf
+++ b/docker/Dockerfile.thumbv7em-none-eabihf
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.thumbv7m-none-eabi
+++ b/docker/Dockerfile.thumbv7m-none-eabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.wasm32-unknown-emscripten
+++ b/docker/Dockerfile.wasm32-unknown-emscripten
@@ -23,7 +23,7 @@ ENV PATH="${EMSDK}:${EMSDK}/emscripten/sdk:${EMSDK}/llvm/clang/bin:${EMSDK}/node
 
 ENTRYPOINT ["/emsdk_portable/entrypoint"]
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   libxml2 \
   python
 

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -10,13 +10,13 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN dpkg --add-architecture i386 && apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install --assume-yes --no-install-recommends \
         wine-stable \
         wine64 \
         wine32 \
         libz-mingw-w64-dev
 
-RUN apt-get install -y --no-install-recommends g++-mingw-w64-x86-64
+RUN apt-get install --assume-yes --no-install-recommends g++-mingw-w64-x86-64
 
 # run-detectors are responsible for calling the correct interpreter for exe
 # files. For some reason it does not work inside a docker container (it works

--- a/docker/android-ndk.sh
+++ b/docker/android-ndk.sh
@@ -19,7 +19,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/android-system.sh
+++ b/docker/android-system.sh
@@ -44,7 +44,7 @@ EOF
     local purge_list=(default-jre)
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/cmake.sh
+++ b/docker/cmake.sh
@@ -18,7 +18,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -11,7 +11,7 @@ sed -i 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch=amd64,i386] http:\/\/\1.arc
 
 apt-get update
 
-apt-get install -y --no-install-recommends \
+apt-get install --assume-yes --no-install-recommends \
   autoconf \
   automake \
   binutils \

--- a/docker/disabled/Dockerfile.i686-pc-windows-gnu
+++ b/docker/disabled/Dockerfile.i686-pc-windows-gnu
@@ -7,7 +7,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN dpkg --add-architecture i386 && apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install --assume-yes --no-install-recommends \
         wine-stable \
         wine64 \
         wine32 \

--- a/docker/disabled/dragonfly.sh
+++ b/docker/disabled/dragonfly.sh
@@ -25,7 +25,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/dropbear.sh
+++ b/docker/dropbear.sh
@@ -20,7 +20,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/emscripten.sh
+++ b/docker/emscripten.sh
@@ -16,7 +16,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -24,7 +24,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -96,7 +96,7 @@ main() {
     apt-get update
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/mingw.sh
+++ b/docker/mingw.sh
@@ -9,7 +9,7 @@ main() {
 
     # Install mingw (with sjlj exceptions) to get the dependencies right
     # Later we replace these packages with the new ones
-    apt-get install -y --no-install-recommends g++-mingw-w64-i686
+    apt-get install --assume-yes --no-install-recommends g++-mingw-w64-i686
 
     local td=$(mktemp -d)
 
@@ -22,7 +22,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep > /dev/null; then
-            apt-get install -y --no-install-recommends $dep
+            apt-get install --assume-yes --no-install-recommends $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -30,7 +30,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -23,7 +23,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -44,7 +44,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -26,7 +26,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/docker/xargo.sh
+++ b/docker/xargo.sh
@@ -13,7 +13,7 @@ main() {
     local purge_list=()
     for dep in ${dependencies[@]}; do
         if ! dpkg -L $dep; then
-            apt-get install --no-install-recommends -y $dep
+            apt-get install --no-install-recommends --assume-yes $dep
             purge_list+=( $dep )
         fi
     done

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -38,7 +38,7 @@ pub fn register(target: &Target, verbose: bool) -> Result<()> {
         "mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && \
             echo ':wine:M::MZ::/usr/bin/run-detectors:' > /proc/sys/fs/binfmt_misc/register"
     } else {
-        "apt-get update && apt-get install --no-install-recommends -y \
+        "apt-get update && apt-get install --no-install-recommends --assume-yes \
             binfmt-support qemu-user-static"
     };
 


### PR DESCRIPTION
This little change makes it even easier for someone to create their own Dockerfile: they simply copy an example and start listing the packages they need. Without `--assume-yes`, `apt-get install` will try to interactively ask for confirmation, and fail since `docker build` runs it in a non-interactive environment.