### PR TITLE
Prevent pkg-config from being removed in image

### DIFF
--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -10,11 +10,9 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN mkdir /usr/arm-linux-gnueabihf && \
-    apt-get install --assume-yes --no-install-recommends curl xz-utils && \
     cd /usr/arm-linux-gnueabihf && \
     curl -L https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz | \
-    tar --strip-components 1 -xJ && \
-    apt-get purge --auto-remove -y curl xz-utils
+    tar --strip-components 1 -xJ
 
 ENV PATH /usr/arm-linux-gnueabihf/bin:$PATH
 


### PR DESCRIPTION
Currently, installing the toolchain for `arm-unknown-linux-gnueabihf`
uses `xz-utils` which gets pruned. This also removes `pkg-config`, so
remove the prune altogether to keep both packages. `curl` is also kept
as that was originally installed in `common.sh` as well.

Fixes #422 