### PR TITLE
Allow users to pick cargo for custom target builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ passthrough = [
 
 ### Use Xargo instead of Cargo
 
-By default, `cross` uses `cargo` to build your Cargo project *unless* you are
-building for one of the `thumbv*-none-eabi*` targets; in that case, it uses
-`xargo`. However, you can use the `build.xargo` or `target.{{TARGET}}.xargo` field
-in `Cross.toml` to force the use of `xargo`:
+By default, `cross` uses `xargo` to build your Cargo project only for all
+non-standard targets (i.e. something not reported by rustc/rustup). However,
+you can use the `build.xargo` or `target.{{TARGET}}.xargo` field in
+`Cross.toml` to force the use of `xargo`:
 
 ``` toml
 # all the targets will use `xargo`
@@ -216,8 +216,8 @@ Or,
 xargo = true
 ```
 
-Note that `xargo = false` has no effect as you can't use `cargo` with targets
-that only support `xargo`.
+`xargo = false` will work the opposite way (pick cargo always) and is useful
+when building for custom targets that you know to work with cargo.
 
 ## Supported targets
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,10 @@ fn run() -> Result<ExitStatus> {
             }
             .unwrap_or_else(|| !target.is_builtin() || !available_targets.contains(&target));
 
-            if !uses_xargo && !available_targets.is_installed(&target) {
+            if !uses_xargo
+                && !available_targets.is_installed(&target)
+                && available_targets.contains(&target)
+            {
                 rustup::install(&target, &toolchain, verbose)?;
             } else if !rustup::component_is_installed("rust-src", &toolchain, verbose)? {
                 rustup::install_component("rust-src", &toolchain, verbose)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,14 +249,12 @@ fn run() -> Result<ExitStatus> {
             }
 
             let available_targets = rustup::available_targets(&toolchain, verbose)?;
-            let uses_xargo = !target.is_builtin() ||
-                !available_targets.contains(&target) ||
-                if let Some(toml) = toml.as_ref() {
-                    toml.xargo(&target)?
-                } else {
-                    None
-                }
-                .unwrap_or(false);
+            let uses_xargo = if let Some(toml) = toml.as_ref() {
+                toml.xargo(&target)?
+            } else {
+                None
+            }
+            .unwrap_or_else(|| !target.is_builtin() || !available_targets.contains(&target));
 
             if !uses_xargo && !available_targets.is_installed(&target) {
                 rustup::install(&target, &toolchain, verbose)?;


### PR DESCRIPTION
This is an attempt to fix https://github.com/rust-embedded/cross/issues/325.

We want to use the target `x86_64-alpine-linux-musl` (available from alpine's rustc) to build musl-based binaries and when using cross with something not in the standard rustc/rustup targets, cross errors out as detailed in the issue above. 

For a non-standard target, cross defaults to using `xargo` right now (behavior introduced in https://github.com/rust-embedded/cross/pull/217), but in our case, since we want `cargo` to run ultimately, I had to also ensure that setting `xargo = false` actually works from the cross config file. If there's a better way of handling this without breaking the current default behavior, please let me know.

Also updated the docs on xargo usage accordingly (including the parts that were lagging even without this PR).

---

A working example of cross use based on the changes here are available at:
https://github.com/wayfair-tremor/tremor-runtime/blob/f72e133f971adca67f6e6b6e265a4f5d5e96380d/Cross.toml#L30-L37

---

Thanks for providing a tool like cross btw! It's been really useful to us as we are looking to streamline our release process 😃 