### PR TITLE
Change CI to build with Rust 1.32 and document that as MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
 This crate is guaranteed to compile on stable Rust 1.32.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
+Some cross-compilation targets require a later Rust version, and using Xargo
+requires a nightly Rust toolchain.
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.32.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 Some cross-compilation targets require a later Rust version, and using Xargo

--- a/README.md
+++ b/README.md
@@ -329,6 +329,11 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
   work because `cross` use docker containers only mounts the Cargo project so
   the container doesn't have access to the rest of the filesystem.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.32.0 and up. It *might*
+compile with older versions but that may change in any new patch release.
+
 ## License
 
 Licensed under either of

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
       vmImage: $(VM_IMAGE)
     variables:
       VM_IMAGE: ubuntu-latest
-      TOOLCHAIN: stable
+      TOOLCHAIN: 1.32.0
       CARGO_NET_RETRY: 3
       CARGO_HTTP_CHECK_REVOKE: false
     strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
         powerpc-unknown-linux-gnu:       { TARGET: powerpc-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64-unknown-linux-gnu:     { TARGET: powerpc64-unknown-linux-gnu,     CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64le-unknown-linux-gnu:   { TARGET: powerpc64le-unknown-linux-gnu,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
-        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1, TOOLCHAIN: 1.34.0 }
+        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1, TOOLCHAIN: 1.42.0 }
         s390x-unknown-linux-gnu:         { TARGET: s390x-unknown-linux-gnu,         CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         sparc64-unknown-linux-gnu:       { TARGET: sparc64-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         x86_64-unknown-linux-gnu:        { TARGET: x86_64-unknown-linux-gnu,        CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: native qemu-user qemu-system, DEPLOY: 1, CRATES_IO_PUBLISH: 1 }
@@ -62,7 +62,7 @@ jobs:
         x86_64-unknown-netbsd:           { TARGET: x86_64-unknown-netbsd,           CPP: 1, DYLIB: 1, STD: 1 }
         sparcv9-sun-solaris:             { TARGET: sparcv9-sun-solaris,             CPP: 1, DYLIB: 1, STD: 1 }
         x86_64-sun-solaris:              { TARGET: x86_64-sun-solaris,              CPP: 1, DYLIB: 1, STD: 1 }
-        asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1, TOOLCHAIN: 1.38.0 }
+        asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1, TOOLCHAIN: 1.40.0 }
         # `cargo run` fails with an assertion error (https://github.com/rust-lang/cargo/issues/4689) on `wasm32-unknown-emscripten`.
         wasm32-unknown-emscripten:       { TARGET: wasm32-unknown-emscripten,                         STD: 1 }
         thumbv6m-none-eabi:              { TARGET: thumbv6m-none-eabi,                                STD: 1 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
         powerpc-unknown-linux-gnu:       { TARGET: powerpc-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64-unknown-linux-gnu:     { TARGET: powerpc64-unknown-linux-gnu,     CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64le-unknown-linux-gnu:   { TARGET: powerpc64le-unknown-linux-gnu,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
-        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1 }
+        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1, TOOLCHAIN: 1.34.0 }
         s390x-unknown-linux-gnu:         { TARGET: s390x-unknown-linux-gnu,         CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         sparc64-unknown-linux-gnu:       { TARGET: sparc64-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         x86_64-unknown-linux-gnu:        { TARGET: x86_64-unknown-linux-gnu,        CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: native qemu-user qemu-system, DEPLOY: 1, CRATES_IO_PUBLISH: 1 }
@@ -62,14 +62,14 @@ jobs:
         x86_64-unknown-netbsd:           { TARGET: x86_64-unknown-netbsd,           CPP: 1, DYLIB: 1, STD: 1 }
         sparcv9-sun-solaris:             { TARGET: sparcv9-sun-solaris,             CPP: 1, DYLIB: 1, STD: 1 }
         x86_64-sun-solaris:              { TARGET: x86_64-sun-solaris,              CPP: 1, DYLIB: 1, STD: 1 }
-        asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1 }
+        asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1, TOOLCHAIN: 1.38.0 }
         # `cargo run` fails with an assertion error (https://github.com/rust-lang/cargo/issues/4689) on `wasm32-unknown-emscripten`.
         wasm32-unknown-emscripten:       { TARGET: wasm32-unknown-emscripten,                         STD: 1 }
         thumbv6m-none-eabi:              { TARGET: thumbv6m-none-eabi,                                STD: 1 }
         thumbv7em-none-eabi:             { TARGET: thumbv7em-none-eabi,                               STD: 1 }
         thumbv7em-none-eabihf:           { TARGET: thumbv7em-none-eabihf,                             STD: 1 }
         thumbv7m-none-eabi:              { TARGET: thumbv7m-none-eabi,                                STD: 1 }
-        x86_64-pc-windows-msvc:          { TARGET: x86_64-pc-windows-msvc,          CPP: 1,           STD: 1,                   RUN: 1, VM_IMAGE: vs2017-win2016, DEPLOY: 1 }
+        x86_64-pc-windows-msvc:          { TARGET: x86_64-pc-windows-msvc,          CPP: 1,           STD: 1,                   RUN: 1, VM_IMAGE: vs2017-win2016, DEPLOY: 1, TOOLCHAIN: 1.38.0 }
     timeoutInMinutes: 360
     steps:
       - template: ci/azure-install-rust.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
       vmImage: $(VM_IMAGE)
     variables:
       VM_IMAGE: ubuntu-latest
-      TOOLCHAIN: 1.32.0
+      TOOLCHAIN: 1.42.0
       CARGO_NET_RETRY: 3
       CARGO_HTTP_CHECK_REVOKE: false
     strategy:
@@ -32,7 +32,7 @@ jobs:
         powerpc-unknown-linux-gnu:       { TARGET: powerpc-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64-unknown-linux-gnu:     { TARGET: powerpc64-unknown-linux-gnu,     CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         powerpc64le-unknown-linux-gnu:   { TARGET: powerpc64le-unknown-linux-gnu,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
-        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1, TOOLCHAIN: 1.42.0 }
+        riscv64gc-unknown-linux-gnu:     { TARGET: riscv64gc-unknown-linux-gnu,     CPP: 1,           STD: 1, RUN: 1 }
         s390x-unknown-linux-gnu:         { TARGET: s390x-unknown-linux-gnu,         CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         sparc64-unknown-linux-gnu:       { TARGET: sparc64-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-system }
         x86_64-unknown-linux-gnu:        { TARGET: x86_64-unknown-linux-gnu,        CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: native qemu-user qemu-system, DEPLOY: 1, CRATES_IO_PUBLISH: 1 }
@@ -62,14 +62,14 @@ jobs:
         x86_64-unknown-netbsd:           { TARGET: x86_64-unknown-netbsd,           CPP: 1, DYLIB: 1, STD: 1 }
         sparcv9-sun-solaris:             { TARGET: sparcv9-sun-solaris,             CPP: 1, DYLIB: 1, STD: 1 }
         x86_64-sun-solaris:              { TARGET: x86_64-sun-solaris,              CPP: 1, DYLIB: 1, STD: 1 }
-        asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1, TOOLCHAIN: 1.40.0 }
+        asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1 }
         # `cargo run` fails with an assertion error (https://github.com/rust-lang/cargo/issues/4689) on `wasm32-unknown-emscripten`.
         wasm32-unknown-emscripten:       { TARGET: wasm32-unknown-emscripten,                         STD: 1 }
         thumbv6m-none-eabi:              { TARGET: thumbv6m-none-eabi,                                STD: 1 }
         thumbv7em-none-eabi:             { TARGET: thumbv7em-none-eabi,                               STD: 1 }
         thumbv7em-none-eabihf:           { TARGET: thumbv7em-none-eabihf,                             STD: 1 }
         thumbv7m-none-eabi:              { TARGET: thumbv7m-none-eabi,                                STD: 1 }
-        x86_64-pc-windows-msvc:          { TARGET: x86_64-pc-windows-msvc,          CPP: 1,           STD: 1,                   RUN: 1, VM_IMAGE: vs2017-win2016, DEPLOY: 1, TOOLCHAIN: 1.38.0 }
+        x86_64-pc-windows-msvc:          { TARGET: x86_64-pc-windows-msvc,          CPP: 1,           STD: 1,                   RUN: 1, VM_IMAGE: vs2017-win2016, DEPLOY: 1 }
     timeoutInMinutes: 360
     steps:
       - template: ci/azure-install-rust.yml


### PR DESCRIPTION
This PR adds a documented MSRV, per https://github.com/rust-embedded/wg/issues/445

As far as I can tell none of the Azure pipelines use Xargo or nightly Rust, so I think this small change should be sufficient, but we'll see what CI makes of it.