### PR TITLE
Bump Ubuntu container version and MUSL-related libs

### DIFF
--- a/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh
@@ -17,7 +17,8 @@ RUN /musl.sh \
     TARGET=arm-linux-musleabihf \
     "COMMON_CONFIG += --with-arch=armv7-a \
                       --with-float=hard \
-                      --with-mode=thumb"
+                      --with-mode=thumb \
+                      --with-fpu=vfp"
 
 # Allows qemu run dynamic linked binaries
 RUN ln -sf \

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:16.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 main() {
     # arch in the rust target
     local arch="${1}" \
-          kversion=4.9.0-11
+          kversion=4.19.0-10
 
     local debsource="deb http://http.debian.net/debian/ buster main"
     debsource="${debsource}\ndeb http://security.debian.org/ buster/updates main"

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -8,8 +8,8 @@ main() {
     local arch="${1}" \
           kversion=4.9.0-11
 
-    local debsource="deb http://http.debian.net/debian/ stretch main"
-    debsource="${debsource}\ndeb http://security.debian.org/ stretch/updates main"
+    local debsource="deb http://http.debian.net/debian/ buster main"
+    debsource="${debsource}\ndeb http://security.debian.org/ buster/updates main"
 
     local dropbear="dropbear-bin"
 
@@ -37,7 +37,7 @@ main() {
             kernel="${kversion}-5kc-malta"
             ;;
         powerpc)
-            # there is no stretch powerpc port, so we use jessie
+            # there is no buster powerpc port, so we use jessie
             # use a more recent kernel from backports
             kernel=4.9.0-0.bpo.6-powerpc
             debsource="deb http://archive.debian.org/debian jessie main"

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -46,6 +46,7 @@ main() {
     hide_output make install "-j$(nproc)" \
         GCC_VER=9.2.0 \
         MUSL_VER=1.2.0 \
+        BINUTILS_VER=2.33.1 \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
         OUTPUT=/usr/local/ \
         "${@}"

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -19,7 +19,7 @@ hide_output() {
 }
 
 main() {
-    local version=0.9.8
+    local version=0.9.9
 
     local dependencies=(
         ca-certificates
@@ -44,8 +44,8 @@ main() {
     tar --strip-components=1 -xzf "v${version}.tar.gz"
 
     hide_output make install "-j$(nproc)" \
-        GCC_VER=6.4.0 \
-        MUSL_VER=1.1.22 \
+        GCC_VER=9.2.0 \
+        MUSL_VER=1.2.0 \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
         OUTPUT=/usr/local/ \
         "${@}"


### PR DESCRIPTION
Several reasons, including but not limited to:

1) MUSL-compiled OpenSSL benefits from MUSL versions 1.2.0 and up, otherwise it needs to be badly patched, see https://github.com/fornwall/rust-static-builder/issues/3#issuecomment-638085541.
2) DWARFv2 compressed debugging symbols mess up with old toolchains and linkers, see https://github.com/rust-bio/rust-htslib/pull/231.