### PR TITLE
Bump README custom-container cross version to incorporate fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This way you won't have to figure out how to install a cross C toolchain in your
 custom image. Example below:
 
 ``` Dockerfile
-FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.1.16
+FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \


### PR DESCRIPTION
The custom dockerfile example in the README targets cross version 0.1.16, [and is known to not actually work as-is](https://github.com/rust-embedded/cross/commit/3b07a08aa8739a9f22450ceecc56531d108661d5).
The fix for this particular issue was released with cross 0.2, thus this PR bumps the cross version.

This became an issue in my use case as I wanted to cross-compile to a raspberry Pi, and needed to install some external libraries not included in the base images, and ran into issues such as #149 and #35 while attempting to follow the recommendation in the readme.

Bumping the cross version to 0.2.x resolved the above issues for me, and this PR is to help other users that may find themselves running into the same issues when following the readme closely.