### PR TITLE
Fix bug with rustup toolchain overrides causing redundant channel update syncing

### DIFF
--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -28,7 +28,7 @@ pub fn installed_toolchains(verbose: bool) -> Result<Vec<String>> {
         .args(&["toolchain", "list"])
         .run_and_get_stdout(verbose)?;
 
-    Ok(out.lines().map(|l| l.replace(" (default)", "").trim().to_owned()).collect())
+    Ok(out.lines().map(|l| l.replace(" (default)", "").replace(" (override)", "").trim().to_owned()).collect())
 }
 
 pub fn available_targets(toolchain: &str, verbose: bool) -> Result<AvailableTargets> {


### PR DESCRIPTION
The issue is that `cross` is trying to call `rustup toolchain add XX` on every run when toolchain overrides are in use.

Replication & more detail on the issue is given in this repo: https://github.com/kay/cross-toolchain-override-bug

This uses a `rust-toolchain` file to override you can also replicate using `rustup override set 1.45.1` as described [here](https://doc.rust-lang.org/edition-guide/rust-2018/rustup-for-managing-rust-versions.html#managing-versions)

Going by the latest rustup source, [this is the relevant code](https://github.com/rust-lang/rustup/blob/90bd7351693965af52cee7f7ab84a8bbb65706c7/src/cli/common.rs#L488) that enumerates the various annotations outputted for toolchains:  and it looks like `(default)` and `(override)` are the only ones that may be output for running `rustup toolchain list` as `cross -V` would.