### PR TITLE
Add --docker-image argument overriding Cross.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ the default one. Normal Docker behavior applies, so:
 
 - If only `tag` is omitted, then Docker will use the `latest` tag.
 
+You may also pass `--docker-image=my/image:tag` specify a Docker image on a
+per-command basis.
+
 It's recommended to base your custom image on the default Docker image that
 cross uses: `rustembedded/cross:{{TARGET}}-{{VERSION}}` (where `{{VERSION}}` is cross's version).
 This way you won't have to figure out how to install a cross C toolchain in your

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub struct Args {
     pub channel: Option<String>,
     pub target: Option<Target>,
     pub target_dir: Option<PathBuf>,
+    pub docker_image: Option<String>,
     pub docker_in_docker: bool,
 }
 
@@ -20,6 +21,7 @@ pub fn parse(target_list: &TargetList) -> Args {
     let mut target = None;
     let mut target_dir = None;
     let mut sc = None;
+    let mut docker_image = None;
     let mut all: Vec<String> = Vec::new();
 
     {
@@ -50,6 +52,12 @@ pub fn parse(target_list: &TargetList) -> Args {
                     target_dir = Some(PathBuf::from(&td));
                     all.push(format!("--target-dir=/target"));
                 }
+            } else if arg == "--docker-image" {
+                if let Some(di) = args.next() {
+                    docker_image = Some(di);
+                }
+            } else if arg.starts_with("--docker-image=") {
+                docker_image = arg.splitn(2, '=').nth(1).map(String::from);
             } else {
                 if !arg.starts_with('-') && sc.is_none() {
                     sc = Some(Subcommand::from(arg.as_ref()));
@@ -70,6 +78,7 @@ pub fn parse(target_list: &TargetList) -> Args {
         channel,
         target,
         target_dir,
+        docker_image,
         docker_in_docker,
     }
 }


### PR DESCRIPTION
I have a situation where one project needs to be built in multiple environments for the same target triple. I can easily model the environments as separate Docker images, but `Cross.toml` only lets me specify one `image` per target. If I want to build each version automatically, I would have to automatically edit `Cross.toml` to do so.

This PR adds a `--docker-image` argument, allowing me to write a script like:

```sh
cross build --target=foo --docker-image=my/image:first-environment --release
package -o first_environment.pkg target/foo/app

cross build --target=foo --docker-image=my/image:second-environment --release
package -o second_environment.pkg target/foo/app
```

This PR is longer than strictly necessary since I accepted `rustfmt`'s output for any line I touched. I can provide a minimal patch instead if you prefer.