### PR TITLE
Fix i686-pc-windows-gnu

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ terminate.
 | `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-musl`            | 1.1.20 | 6.3.0   |     | N/A   |   ✓    |
 | `i686-linux-android` [2]             | N/A    | 4.9     | ✓   | N/A   |   ✓    |
+| `i686-pc-windows-gnu`                | N/A    | 7.3.0   | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.20 | 6.3.0   |     | N/A   |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.23   | 5.3.1   | ✓   | 4.1.0 |   ✓    |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,9 +22,9 @@ jobs:
         aarch64-unknown-linux-gnu:       { TARGET: aarch64-unknown-linux-gnu,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         arm-unknown-linux-gnueabi:       { TARGET: arm-unknown-linux-gnueabi,       CPP: 1, DYLIB: 1, STD: 1, RUN: 1 }
         arm-unknown-linux-gnueabihf:     { TARGET: arm-unknown-linux-gnueabihf,     CPP: 1, DYLIB: 1, STD: 1, RUN: 1 }
-        armv7-unknown-linux-gnueabihf:   { TARGET: armv7-unknown-linux-gnueabihf,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system                                                                     }
+        armv7-unknown-linux-gnueabihf:   { TARGET: armv7-unknown-linux-gnueabihf,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         i586-unknown-linux-gnu:          { TARGET: i586-unknown-linux-gnu,          CPP: 1, DYLIB: 1, STD: 1, RUN: 1 }
-        i686-unknown-linux-gnu:          { TARGET: i686-unknown-linux-gnu,          CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: native qemu-user qemu-system                                                              }
+        i686-unknown-linux-gnu:          { TARGET: i686-unknown-linux-gnu,          CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: native qemu-user qemu-system }
         mips-unknown-linux-gnu:          { TARGET: mips-unknown-linux-gnu,          CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         mipsel-unknown-linux-gnu:        { TARGET: mipsel-unknown-linux-gnu,        CPP: 1, DYLIB: 1, STD: 1, RUN: 1, RUNNERS: qemu-user qemu-system }
         mips64-unknown-linux-gnuabi64:   { TARGET: mips64-unknown-linux-gnuabi64,   CPP: 1, DYLIB: 1, STD: 1, RUN: 1 }
@@ -39,7 +39,7 @@ jobs:
         aarch64-unknown-linux-musl:      { TARGET: aarch64-unknown-linux-musl,                        STD: 1, RUN: 1 }
         arm-unknown-linux-musleabihf:    { TARGET: arm-unknown-linux-musleabihf,                      STD: 1, RUN: 1 }
         arm-unknown-linux-musleabi:      { TARGET: arm-unknown-linux-musleabi,                        STD: 1, RUN: 1 }
-        armv5te-unknown-linux-gnueabi:  { TARGET: armv5te-unknown-linux-gnueabi,                    STD: 1,                   RUN: 1 }
+        armv5te-unknown-linux-gnueabi:   { TARGET: armv5te-unknown-linux-gnueabi,                     STD: 1,                   RUN: 1 }
         armv5te-unknown-linux-musleabi:  { TARGET: armv5te-unknown-linux-musleabi,                    STD: 1,                   RUN: 1 }
         armv7-unknown-linux-musleabihf:  { TARGET: armv7-unknown-linux-musleabihf,                    STD: 1, RUN: 1 }
         i586-unknown-linux-musl:         { TARGET: i586-unknown-linux-musl,                           STD: 1, RUN: 1 }
@@ -54,8 +54,7 @@ jobs:
         x86_64-linux-android:            { TARGET: x86_64-linux-android,            CPP: 1,           STD: 1, RUN: 1 }
         x86_64-apple-darwin:             { TARGET: x86_64-apple-darwin,             CPP: 1, DYLIB: 1, STD: 1,                   RUN: 1, VM_IMAGE: macOS-latest, DEPLOY: 1 }
         x86_64-pc-windows-gnu:           { TARGET: x86_64-pc-windows-gnu,           CPP: 1,           STD: 1,                   RUN: 1 }
-        # `cargo build` fails with undefined symbols (https://github.com/rust-lang/rust/issues/32859) on `i686-pc-windows-gnu`.
-      # i686-pc-windows-gnu:             { TARGET: i686-pc-windows-gnu,             CPP: 1,           STD: 1,                   RUN: 1 }
+        i686-pc-windows-gnu:             { TARGET: i686-pc-windows-gnu,             CPP: 1,           STD: 1,                   RUN: 1 }
       # x86_64-unknown-dragonfly:        { TARGET: x86_64-unknown-dragonfly,        CPP: 1, DYLIB: 1,         TOOLCHAIN: nightly }
       # i686-unknown-freebsd:            { TARGET: i686-unknown-freebsd,                    DYLIB: 1, STD: 1 }
       # x86_64-unknown-freebsd:          { TARGET: x86_64-unknown-freebsd,                  DYLIB: 1, STD: 1 }

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -3,6 +3,9 @@ FROM ubuntu:18.04
 COPY common.sh /
 RUN /common.sh
 
+COPY cmake.sh /
+RUN /cmake.sh
+
 COPY xargo.sh /
 RUN /xargo.sh
 

--- a/docker/mingw.sh
+++ b/docker/mingw.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -xe
+set -x
+set -euo pipefail
 
 main() {
     # Ubuntu mingw packages for i686 uses sjlj exceptions, but rust target

--- a/docker/mingw.sh
+++ b/docker/mingw.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
-set -x
+set -xe
 
 main() {
     # Ubuntu mingw packages for i686 uses sjlj exceptions, but rust target
     # i686-pc-windows-gnu uses dwarf exceptions. So we build mingw packages
     # that are compatible with rust.
+
+    # Enable source
+    sed -i 's/# deb-src/deb-src/g' /etc/apt/sources.list
+    apt-get update
 
     # Install mingw (with sjlj exceptions) to get the dependencies right
     # Later we replace these packages with the new ones
@@ -15,7 +19,6 @@ main() {
     while IFS='' read -r dep; do dependencies+=("${dep}"); done < \
       <(apt-cache showsrc gcc-mingw-w64-i686 | grep Build | cut -d: -f2 | tr , '\n' | cut -d' ' -f2 | sort | uniq)
 
-    apt-get update
     local purge_list=()
     for dep in "${dependencies[@]}"; do
         if ! dpkg -L "${dep}" > /dev/null; then
@@ -27,15 +30,13 @@ main() {
     local td
     td="$(mktemp -d)"
 
-    pushd "${td}" || exit 1
+    pushd "${td}"
 
     apt-get source gcc-mingw-w64-i686
-    pushd gcc-mingw-w64-* || exit 1
+    pushd gcc-mingw-w64-*
 
     # We are using dwarf exceptions instead of sjlj
     sed -i -e 's/libgcc_s_sjlj-1/libgcc_s_dw2-1/g' debian/gcc-mingw-w64-i686.install
-    # Do not install gcc with win32 thread model
-    sed -i -e '/i686-w64-mingw32-gcc-win32/d' debian/gcc-mingw-w64-i686.install
 
     # Only build i686 packages (disable x86_64)
     patch -p0 <<'EOF'
@@ -95,7 +96,7 @@ EOF
 -targets := i686-w64-mingw32 x86_64-w64-mingw32
 +targets := i686-w64-mingw32
 -threads := posix win32
-+threads := posix
++threads := posix win32
 
  # Hardening on the host, none on the target
 @@ -216,6 +216,10 @@
@@ -121,8 +122,8 @@ EOF
       apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
     fi
 
-    popd || exit 1
-    popd || exit 1
+    popd
+    popd
 
     rm -rf "${td}"
     rm "${0}"

--- a/docker/mingw.sh
+++ b/docker/mingw.sh
@@ -96,8 +96,7 @@ EOF
 
 -targets := i686-w64-mingw32 x86_64-w64-mingw32
 +targets := i686-w64-mingw32
--threads := posix win32
-+threads := posix win32
+ threads := posix win32
 
  # Hardening on the host, none on the target
 @@ -216,6 +216,10 @@


### PR DESCRIPTION
The build command in mingw.sh script was failing but the script continued to run and returned 0. The result was that the mingw toolchain with sjlj was being used in the image, not the one with dwarf expectation we are trying to build!

I set the option -e and fixed the script.