### PR TITLE
Add a way to choose Podman instead of Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ overlayfs can not be unmounted correctly by Docker if the child container still
 accesses it.
 
 
+### Explicitly choose the container engine
+
+By default, `cross` tries to use [Docker] or [Podman], in that order.
+If you want to choose a container engine explicitly, you can set the
+binary name (or path) using the `CROSS_CONTAINER_ENGINE`
+environment variable.
+
+For example in case you want use [Podman], you can set `CROSS_CONTAINER_ENGINE=podman`.
+
 ### Passing environment variables into the build environment
 
 By default, `cross` does not pass any environment variables into the build

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -17,7 +17,15 @@ const DOCKER: &str = "docker";
 const PODMAN: &str = "podman";
 
 fn get_container_engine() -> Result<std::path::PathBuf> {
-    which::which(DOCKER).or_else(|_| which::which(PODMAN)).map_err(|e| e.into())
+    let container_engine = env::var("CROSS_CONTAINER_ENGINE").unwrap_or_default();
+
+    if container_engine.is_empty() {
+        which::which(DOCKER)
+            .or_else(|_| which::which(PODMAN))
+            .map_err(|e| e.into())
+    } else {
+        which::which(container_engine).map_err(|e| e.into())
+    }
 }
 
 pub fn docker_command(subcommand: &str) -> Result<Command> {


### PR DESCRIPTION
By default, `cross` tries to use Docker or Podman, with the former to have priority. In you want to use other container engine or explicitly choose one you can set the name of binary (or the path) in `CROSS_CONTAINER_ENGINE` environment variable.

For example in case you want use Podman, you can set `CROSS_CONTAINER_ENGINE=podman`.

