### PR TITLE
Fix MUSL CI

### DIFF
--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -43,11 +43,15 @@ main() {
     curl --retry 3 -sSfL "https://github.com/richfelker/musl-cross-make/archive/v${version}.tar.gz" -O
     tar --strip-components=1 -xzf "v${version}.tar.gz"
 
+    # Don't depend on the mirrors of sabotage linux that musl-cross-make uses.
+    local linux_headers_site=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs
+
     hide_output make install "-j$(nproc)" \
         GCC_VER=9.2.0 \
         MUSL_VER=1.2.0 \
         BINUTILS_VER=2.33.1 \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
+        LINUX_HEADERS_SITE=$linux_headers_site \
         OUTPUT=/usr/local/ \
         "${@}"
 


### PR DESCRIPTION
cc @reitermarkus, this is what caused the MUSL CI failure in https://github.com/rust-embedded/cross/pull/475

Upstream Rust has also been hitting this and has created this mirror.