### PR TITLE
Update armv7-unknown-linux-gnueabihf base image

### DIFF
--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 COPY common.sh /
 RUN /common.sh


### PR DESCRIPTION
I was attempting to cross compile gtk app (using druid) and needed to create custom cross image with the relevant libs installed. The version of the libs needed required required a higher version of ubuntu, hence this PR. Thanks