### PR TITLE
Add support for more hosts and simplify/unify host support checks

### DIFF
--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 main() {
     local arch="${1}"
 
-    local sqlite_ver=3.34.0,1 \
-          openssl_ver=1.1.1j,1 \
+    local sqlite_ver=3.34.1,1 \
+          openssl_ver=1.1.1k_1,1 \
           target="${arch}-unknown-freebsd12"
 
     local td


### PR DESCRIPTION
This PR enables more freedom when choosing custom host/target combinations and simplifies (unifies) logic and behavior regarding when to build natively (using local toolchain) and when to use docker image based toolchain. If users explicitly passes `--target ...` option to `cross` it will always use docker image based toolchain (unless a target explicitly opts-out) and only use the local toolchain if `--target` option is not present.

Furthermore, no longer make any assumptions about the host, and let users use any host. It is the user's choice and responsibility to choose a working host platform and `cross` should not artificially limit use cases.

This PR also addresses:
- [436](https://github.com/rust-embedded/cross/issues/436)