### PR TITLE
don't set RUSTFLAGS in aarch64-musl image

### DIFF
--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -21,10 +21,9 @@ RUN ln -sf \
     /usr/local/aarch64-linux-musl/lib/ld-musl-aarch64.so.1
 ENV QEMU_LD_PREFIX=/usr/local/aarch64-linux-musl
 
-# Workaround for https://github.com/rust-lang/rust/issues/46651
-ENV RUSTFLAGS="-C link-arg=-lgcc"
+COPY aarch64-linux-musl-gcc.sh /usr/bin/
 
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc.sh \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER=qemu-aarch64 \
     CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
     CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++ \

--- a/docker/aarch64-linux-musl-gcc.sh
+++ b/docker/aarch64-linux-musl-gcc.sh
@@ -7,11 +7,13 @@
 set -euo pipefail
 
 main() {
-    local release=$(rustc -Vv | grep '^release:' | cut -d ':' -f2)
+    local release=
+    release=$(rustc -Vv | grep '^release:' | cut -d ':' -f2)
     # NOTE we assume `major` is always "1"
-    local minor=$(echo $release | cut -d '.' -f2)
+    local minor=
+    minor=$(echo "$release" | cut -d '.' -f2)
 
-    if (( $minor >= 48 )); then
+    if (( minor >= 48 )); then
         # no workaround
         aarch64-linux-musl-gcc "${@}"
     else

--- a/docker/aarch64-linux-musl-gcc.sh
+++ b/docker/aarch64-linux-musl-gcc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# this linker wrapper works around issue https://github.com/rust-lang/rust/issues/46651
+# which affects toolchains older than 1.48
+# older toolchains require the `-lgcc` linker flag otherwise they fail to link
+
+set -euo pipefail
+
+main() {
+    local release=$(rustc -Vv | grep '^release:' | cut -d ':' -f2)
+    # NOTE we assume `major` is always "1"
+    local minor=$(echo $release | cut -d '.' -f2)
+
+    if (( $minor >= 48 )); then
+        # no workaround
+        aarch64-linux-musl-gcc "${@}"
+    else
+        # apply workaround
+        aarch64-linux-musl-gcc "${@}" -lgcc
+    fi
+}
+
+main "${@}"


### PR DESCRIPTION
instead use a linker wrapper to work around issue rust-lang/rust#46651
not setting RUSTFLAGS inside the container lets end users pass rustc flags via `.cargo/config`
this is an alternative to #464 that doesn't require bumping the MSRV of the `aarch64-unknown-linux-musl` target (that is the aarch64-musl image will continue to work with Rust 1.42 where bug rust-lang/rust#46651 is still presen )