### PR TITLE
bump linux-image version to fix CI

### DIFF
--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 COPY common.sh /
 RUN /common.sh

--- a/docker/android-ndk.sh
+++ b/docker/android-ndk.sh
@@ -30,6 +30,7 @@ main() {
     pushd "${td}"
     curl --retry 3 -sSfL "${NDK_URL}" -O
     unzip -q android-ndk-*.zip
+    rm android-ndk-*.zip
     pushd android-ndk-*
     ./build/tools/make_standalone_toolchain.py \
       --install-dir /android-ndk \

--- a/docker/android-system.sh
+++ b/docker/android-system.sh
@@ -54,43 +54,36 @@ EOF
     curl --retry 3 -sSfL https://storage.googleapis.com/git-repo-downloads/repo -O
     chmod +x repo
 
-    # the `repo` tool requires python3 so change the default python interpreter
-    ln -sf python3 /usr/bin/python
-
     # this is the minimum set of modules that are need to build bionic
     # this was created by trial and error
-    ./repo init -u https://android.googlesource.com/platform/manifest -b android-5.0.0_r1
-    ./repo sync -c bionic
-    ./repo sync -c build
-    ./repo sync -c external/compiler-rt
-    ./repo sync -c external/jemalloc
-    ./repo sync -c external/libcxx
-    ./repo sync -c external/libcxxabi
-    ./repo sync -c external/libselinux
-    ./repo sync -c external/mksh
-    ./repo sync -c external/openssl
-    ./repo sync -c external/stlport
-    ./repo sync -c prebuilts/clang/linux-x86/host/3.5
-    ./repo sync -c system/core
+    python3 ./repo init -u https://android.googlesource.com/platform/manifest -b android-5.0.0_r1
+    python3 ./repo sync -c bionic
+    python3 ./repo sync -c build
+    python3 ./repo sync -c external/compiler-rt
+    python3 ./repo sync -c external/jemalloc
+    python3 ./repo sync -c external/libcxx
+    python3 ./repo sync -c external/libcxxabi
+    python3 ./repo sync -c external/libselinux
+    python3 ./repo sync -c external/mksh
+    python3 ./repo sync -c external/openssl
+    python3 ./repo sync -c external/stlport
+    python3 ./repo sync -c prebuilts/clang/linux-x86/host/3.5
+    python3 ./repo sync -c system/core
     case "${arch}" in
         arm)
-            ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
         ;;
         arm64)
-            ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
-            ./repo sync prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9
+            python3 ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9
         ;;
         x86)
-            ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
         ;;
         x86_64)
-            ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
         ;;
     esac
-
-    # revert default python interpreter; the code we are going to build expects
-    # `/usr/bin/python` to be a python2 interpreter
-    ln -sf python2 /usr/bin/python
 
     # avoid build tests
     rm bionic/linker/tests/Android.mk bionic/tests/Android.mk bionic/benchmarks/Android.mk

--- a/docker/android-system.sh
+++ b/docker/android-system.sh
@@ -17,6 +17,7 @@ main() {
         g++-multilib
         make
         python
+        python3
     )
 
     # fake java and javac, it is not necessary for what we build, but the build
@@ -53,6 +54,9 @@ EOF
     curl --retry 3 -sSfL https://storage.googleapis.com/git-repo-downloads/repo -O
     chmod +x repo
 
+    # the `repo` tool requires python3 so change the default python interpreter
+    ln -sf python3 /usr/bin/python
+
     # this is the minimum set of modules that are need to build bionic
     # this was created by trial and error
     ./repo init -u https://android.googlesource.com/platform/manifest -b android-5.0.0_r1
@@ -83,6 +87,10 @@ EOF
             ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
         ;;
     esac
+
+    # revert default python interpreter; the code we are going to build expects
+    # `/usr/bin/python` to be a python2 interpreter
+    ln -sf python2 /usr/bin/python
 
     # avoid build tests
     rm bionic/linker/tests/Android.mk bionic/tests/Android.mk bionic/benchmarks/Android.mk

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 main() {
     # arch in the rust target
     local arch="${1}" \
-          kversion=4.19.0-10
+          kversion=4.19.0-11
 
     local debsource="deb http://http.debian.net/debian/ buster main"
     debsource="${debsource}\ndeb http://security.debian.org/ buster/updates main"


### PR DESCRIPTION
the Dockerfiles try to use linux-image-4.19.0-10 which no longer exists in the debian package repository; this is making CI fail: https://dev.azure.com/rust-embedded/cross/_build/results?buildId=772&view=logs&j=e6deedce-f53c-5dcc-524e-14349f140ffd&t=9e60ab89-47e0-5dc9-e657-a2fbb695cbf9&l=6521
this PR updates the package version (revision?) to linux-image-4.19.0-**11**