### PR TITLE
fix ci: bump openssl version in freebsd

### DIFF
--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -7,7 +7,7 @@ main() {
     local arch="${1}"
 
     local sqlite_ver=3.33.0,1 \
-          openssl_ver=1.1.1h,1 \
+          openssl_ver=1.1.1i,1 \
           target="${arch}-unknown-freebsd12"
 
     local td


### PR DESCRIPTION
https://pkg.freebsd.org/FreeBSD:12:i386/quarterly/All/openssl-1.1.1h,1.txz returns 404 and it's making the freebsd build job fail in CI
OpenSSL 1.1.1i was released ~8 days ago and that URL seems to work so this PR bumps the openssl version