### PR TITLE
Make the `USER` variable to `docker` optional

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -158,8 +158,11 @@ pub fn run(target: &Target,
     docker
         .args(&["-e", "XARGO_HOME=/xargo"])
         .args(&["-e", "CARGO_HOME=/cargo"])
-        .args(&["-e", "CARGO_TARGET_DIR=/target"])
-        .args(&["-e", &format!("USER={}", id::username().unwrap().unwrap())]);
+        .args(&["-e", "CARGO_TARGET_DIR=/target"]);
+
+    if let Some(username) = id::username().unwrap() {
+        docker.args(&["-e", &format!("USER={}", username)]);
+    }
 
     if let Ok(value) = env::var("QEMU_STRACE") {
         docker.args(&["-e", &format!("QEMU_STRACE={}", value)]);


### PR DESCRIPTION
Populating this variable fails under Linux if the local user doesn't have a username. This may happen when using Docker and mapping a user ID from the host into a container, such as when using `--user=$(id -u):$(id -g)`. I suggest making the `USER` environment variable passed to `docker` optional, which allows `cross` to work in the given scenario.