### PR TITLE
FreeBSD: add libssp

### DIFF
--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 main() {
     local arch="${1}"
 
-    local sqlite_ver=3.33.0,1 \
+    local sqlite_ver=3.34.0,1 \
           openssl_ver=1.1.1i,1 \
           target="${arch}-unknown-freebsd12"
 

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -73,9 +73,10 @@ main() {
     cp "${td}/freebsd/lib/libm.so.5" "${destdir}/lib"
     cp "${td}/freebsd/lib/libthr.so.3" "${destdir}/lib"
     cp "${td}/freebsd/lib/libutil.so.9" "${destdir}/lib"
+    cp "${td}/freebsd/lib/libssp.so.0" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.so.1" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.a" "${destdir}/lib"
-    cp "${td}/freebsd/usr/lib"/lib{c,util,m}.a "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp,ssp_nonshared}.a "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{rt,execinfo}.so.1 "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/{crt1,Scrt1,crti,crtn}.o "${destdir}/lib"
 
@@ -86,6 +87,7 @@ main() {
     ln -s librt.so.1 "${destdir}/lib/librt.so"
     ln -s libutil.so.9 "${destdir}/lib/libutil.so"
     ln -s libthr.so.3 "${destdir}/lib/libpthread.so"
+    ln -s libssp.so.0 "${destdir}/lib/libssp.so"
 
     cd gcc-build
     ../gcc/configure \


### PR DESCRIPTION
This is required to build some native projects
which is build with -fstack-protector when linked.

Also update sqlite3 version (quarterly is updated)