### PR TITLE
Add support for building ARM64 iOS crates on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,7 @@ jobs:
         i686-linux-android:              { TARGET: i686-linux-android,              CPP: 1,           STD: 1, RUN: 1 }
         x86_64-linux-android:            { TARGET: x86_64-linux-android,            CPP: 1,           STD: 1, RUN: 1 }
         x86_64-apple-darwin:             { TARGET: x86_64-apple-darwin,             CPP: 1, DYLIB: 1, STD: 1,                   RUN: 1, VM_IMAGE: macOS-latest, DEPLOY: 1 }
+        aarch64-apple-ios:               { TARGET: aarch64-apple-ios,               CPP: 1,           STD: 1 }
         x86_64-pc-windows-gnu:           { TARGET: x86_64-pc-windows-gnu,           CPP: 1,           STD: 1,                   RUN: 1 }
         i686-pc-windows-gnu:             { TARGET: i686-pc-windows-gnu,             CPP: 1,           STD: 1,                   RUN: 1 }
       # x86_64-unknown-dragonfly:        { TARGET: x86_64-unknown-dragonfly,        CPP: 1, DYLIB: 1,         TOOLCHAIN: nightly }

--- a/docker/Dockerfile.aarch64-apple-ios
+++ b/docker/Dockerfile.aarch64-apple-ios
@@ -20,6 +20,6 @@ RUN /apple-llvm.sh
 
 
 ENV CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=aarch64-apple-darwin-clang \
-	CC_aarch64_unknown_linux_gnu=aarch64-apple-darwin-clang \
-	CXX_aarch64_unknown_linux_gnu=aarch64-apple-darwin-clang++ \
+	CC_aarch64_apple_ios=aarch64-apple-darwin-clang \
+	CXX_aarch64_apple_ios=aarch64-apple-darwin-clang++ \
 	SDKROOT=/opt/iPhoneOS.sdk

--- a/docker/Dockerfile.aarch64-apple-ios
+++ b/docker/Dockerfile.aarch64-apple-ios
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+COPY apple-sdk.sh /
+RUN /apple-sdk.sh
+
+COPY apple-cctools.sh /
+RUN /apple-cctools.sh
+
+COPY apple-llvm.sh /
+RUN /apple-llvm.sh
+
+
+ENV CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=aarch64-apple-darwin-clang \
+	CC_aarch64_unknown_linux_gnu=aarch64-apple-darwin-clang \
+	CXX_aarch64_unknown_linux_gnu=aarch64-apple-darwin-clang++ \
+	SDKROOT=/opt/iPhoneOS.sdk

--- a/docker/apple-cctools.sh
+++ b/docker/apple-cctools.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+    local cctools_commit=30518813875aed656aa7f18b6d485feee25f8f87
+
+    install_packages curl python3 clang
+    # Don't use install_packages, we want to keep this.
+    apt-get install --assume-yes --no-install-recommends libssl-dev
+
+    local td
+    td="$(mktemp -d)"
+
+    pushd "${td}"
+
+    curl --retry 3 -sSfL "https://github.com/okanon/iPhoneOS.sdk/releases/download/v0.0.1/iPhoneOS13.2.sdk.tar.gz" -o iPhoneOS13.2.sdk.tar.gz
+    curl --retry 3 -sSfL "https://github.com/tpoechtrager/cctools-port/archive/${cctools_commit}.tar.gz" -O
+    tar --strip-components=1 -xaf "${cctools_commit}.tar.gz"
+
+	cd usage_examples/ios_toolchain
+	sed -i "s/arm-apple-darwin11/aarch64-apple-darwin/" build.sh
+    ./build.sh "${td}/iPhoneOS13.2.sdk.tar.gz" arm64
+
+	mkdir -p /usr/local/bin
+	cp -af target/bin/* /usr/local/bin
+
+    purge_packages
+
+
+    popd
+
+    rm -rf "${td}"
+    rm "${0}"
+}
+
+main "${@}"

--- a/docker/apple-llvm.sh
+++ b/docker/apple-llvm.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+    local version=apple/stable/20200714
+
+    install_packages curl ninja-build python3 llvm clang lld
+
+    local td
+    td="$(mktemp -d)"
+
+    pushd "${td}"
+
+    curl --retry 3 -sSfL "https://github.com/apple/llvm-project/archive/${version}.tar.gz" -o apple-llvm.tar.gz
+    tar --strip-components=1 -xaf apple-llvm.tar.gz
+
+	mkdir build && cd build
+
+    cmake -G Ninja ../llvm \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr/local \
+		-DLLVM_TARGETS_TO_BUILD="AArch64" \
+		-DLLVM_BUILD_TOOLS=On \
+		-DLLVM_INCLUDE_TOOLS=On \
+		-DLLVM_INSTALL_BINUTILS_SYMLINKS=On \
+		-DLLVM_INSTALL_CCTOOLS_SYMLINKS=On \
+		-DLLVM_BUILD_EXAMPLES=Off \
+		-DLLVM_INCLUDE_EXAMPLES=Off \
+		-DLLVM_BUILD_TESTS=Off \
+		-DLLVM_INCLUDE_TESTS=Off \
+		-DLLVM_BUILD_BENCHMARKS=Off \
+		-DLLVM_INCLUDE_BENCHMARKS=Off \
+		-DLLVM_ENABLE_PROJECTS="clang;lld" \
+		-DLLVM_USE_LINKER=lld \
+		-DCMAKE_C_COMPILER=clang \
+		-DCMAKE_CXX_COMPILER=clang++
+	
+	cmake --build .
+	cmake --install .
+
+    purge_packages
+
+    popd
+
+    rm -rf "${td}"
+    rm "${0}"
+}
+
+main "${@}"

--- a/docker/apple-sdk.sh
+++ b/docker/apple-sdk.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+    install_packages curl unzip xz-utils
+
+    local td
+    td="$(mktemp -d)"
+
+    pushd "${td}"
+
+	# Adapted from https://gist.github.com/1Conan/4347fd5f604cfe6116f7acb0237ef155
+	# and https://github.com/ProcursusTeam/Procursus/blob/master/Makefile
+
+    curl --retry 3 -sSfL "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz" -o macOS.sdk.tar.xz
+	curl --retry 3 -sSfL "https://github.com/okanon/iPhoneOS.sdk/releases/download/v0.0.1/iPhoneOS13.2.sdk.tar.gz" -o iOS.sdk.tar.gz
+	curl --retry 3 -sSfL "https://cdn.discordapp.com/attachments/688121419980341282/725234834024431686/c.zip" -o cpp.zip
+    
+	mkdir -p /opt/{iPhoneOS,MacOSX}.sdk
+	tar --strip-components=1 -xaf macOS.sdk.tar.xz -C /opt/MacOSX.sdk
+	tar --strip-components=1 -xaf iOS.sdk.tar.gz -C /opt/iPhoneOS.sdk
+	unzip -o cpp.zip -d /opt/iPhoneOS.sdk/usr/include
+
+	# Copy headers from MacOSX.sdk
+	mkdir -p /opt/iPhoneOS.sdk/usr/include/IOKit
+	cp -af /opt/MacOSX.sdk/usr/include/{arpa,net,xpc} /opt/iPhoneOS.sdk/usr/include
+	cp -af /opt/MacOSX.sdk/usr/include/objc/objc-runtime.h /opt/iPhoneOS.sdk/usr/include/objc
+	cp -af /opt/MacOSX.sdk/usr/include/libkern/OSTypes.h /opt/iPhoneOS.sdk/usr/include/libkern
+	cp -af /opt/MacOSX.sdk/usr/include/sys/{tty*,proc*,ptrace,kern*,random,vnode}.h /opt/iPhoneOS.sdk/usr/include/sys
+	cp -af /opt/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Headers/* /opt/iPhoneOS.sdk/usr/include/IOKit
+	cp -af /opt/MacOSX.sdk/usr/include/{ar,launch,libcharset,localcharset,libproc,tzfile}.h /opt/iPhoneOS.sdk/usr/include
+	cp -af /opt/MacOSX.sdk/usr/include/mach/{*.defs,{mach_vm,shared_region}.h} /opt/iPhoneOS.sdk/usr/include/mach
+	cp -af /opt/MacOSX.sdk/usr/include/mach/machine/*.defs /opt/iPhoneOS.sdk/usr/include/mach/machine
+	curl --retry 3 -sSfL "https://cdn.jsdelivr.net/gh/ProcursusTeam/Procursus/build_info/availability.h" -o /opt/iPhoneOS.sdk/usr/include/os/availability.h
+
+	# Delete the macOS SDK, we don't need it anymore.
+	rm -rf /opt/MacOSX.sdk
+
+	# Patch the iOS headers
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/stdlib.h
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/time.h
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/unistd.h
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/mach/task.h
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/mach/mach_host.h
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/ucontext.h
+	sed -i -E s/'__IOS_PROHIBITED|__TVOS_PROHIBITED|__WATCHOS_PROHIBITED'//g /opt/iPhoneOS.sdk/usr/include/signal.h
+	sed -i -E /'__API_UNAVAILABLE'/d /opt/iPhoneOS.sdk/usr/include/pthread.h
+
+    popd
+
+    purge_packages
+
+    rm -rf "${td}"
+    rm -rf /var/lib/apt/lists/*
+    rm "${0}"
+}
+
+main "${@}"


### PR DESCRIPTION
Adds support for `cross build --target aarch64-apple-ios` on Linux hosts.

Notes:

 * the [Apple LLVM](https://github.com/apple/llvm-project) is built in the dockerfile
 * there is no support for GCC / GNU utilities, everything is LLVM.
 * the [cctools-port](https://github.com/tpoechtrager/cctools-port) wrapper is used
 * some of the files downloaded should _really_ be mirrored - jsdelivr was the only CDN with support for Github releases, and it has a 50MB limit (quite a bit below the size of the SDK files)