### PR TITLE
specify the `minimal` profile when installing rust toolchain (due to bug in rustup?)

### DIFF
--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -57,7 +57,7 @@ pub fn available_targets(toolchain: &str, verbose: bool) -> Result<AvailableTarg
 
 pub fn install_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     Command::new("rustup")
-        .args(&["toolchain", "add", toolchain])
+        .args(&["toolchain", "add", toolchain, "--profile", "minimal"])
         .run(verbose)
         .chain_err(|| format!("couldn't install toolchain `{}`", toolchain))
 }


### PR DESCRIPTION
this is needed bc of some bug(?) in rustup not being able to install the necessary toolchain without error using the `default` profile, so the `minimal` profile is needed.

see my comment in the rustup project regarding this issue: https://github.com/rust-lang/rustup/issues/2661#issuecomment-783717159

this is the error I get when running cross
```
# clear all toolchains
$ rm -rf ~/.rustup                                       

$ cross build --target aarch64-unknown-linux-gnu
warning: toolchain 'nightly-x86_64-unknown-linux-gnu' may not be able to run on this system.
warning: If you meant to build software to target that platform, perhaps try `rustup target add x86_64-unknown-linux-gnu` instead?
info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu'
info: latest update on 2021-02-22, rust version 1.52.0-nightly (3e826bb11 2021-02-21)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
 15.0 MiB /  15.0 MiB (100 %)  10.0 MiB/s in  1s ETA:  0s
info: downloading component 'rust-std'
 24.9 MiB /  24.9 MiB (100 %)  12.7 MiB/s in  2s ETA:  0s
info: downloading component 'rustc'
 47.9 MiB /  47.9 MiB (100 %)  13.5 MiB/s in  3s ETA:  0s
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'clippy'
info: installing component 'rust-docs'
 15.0 MiB /  15.0 MiB (100 %)   6.0 MiB/s in  2s ETA:  0s
info: rolling back changes
error: failed to install component: 'rust-docs-x86_64-unknown-linux-gnu', detected conflict: '"share/doc/rust/html/std/keyword.self.html"'
error: couldn't install toolchain `nightly-x86_64-unknown-linux-gnu`
caused by: `"rustup" "toolchain" "add" "nightly-x86_64-unknown-linux-gnu"` failed with exit code: Some(1)
note: run with `RUST_BACKTRACE=1` for a backtrace
```

I get the same error when running cross with the following (randomly selected toolchains)
- `aarch64-unknown-linux-gnu`
- `armv7-linux-androideabi`
- `thumbv6m-none-eabi`
- `s390x-unknown-linux-gnu`

`cargo test` seems to pass and cross-compilation seems to work okay now (with this PR).

### Another work-around that isn't this pull request

<details>
    <summary>install the toolchain outside of cross using the `minimal` profile, then run cross command</summary>

```
$ rm -rf ~/.rustup

$ rustup toolchain add nightly-x86_64-unknown-linux-gnu --profile minimal
warning: toolchain 'nightly-x86_64-unknown-linux-gnu' may not be able to run on this system.
warning: If you meant to build software to target that platform, perhaps try `rustup target add x86_64-unknown-linux-gnu` instead?
info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu'
info: latest update on 2021-02-22, rust version 1.52.0-nightly (3e826bb11 2021-02-21)
info: downloading component 'cargo'
info: downloading component 'rust-std'
 24.9 MiB /  24.9 MiB (100 %)  12.4 MiB/s in  2s ETA:  0s
info: downloading component 'rustc'
 47.9 MiB /  47.9 MiB (100 %)  13.6 MiB/s in  3s ETA:  0s
info: installing component 'cargo'
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'rust-std'
 24.9 MiB /  24.9 MiB (100 %)  11.1 MiB/s in  2s ETA:  0s
info: installing component 'rustc'
 47.9 MiB /  47.9 MiB (100 %)  12.6 MiB/s in  3s ETA:  0s

  nightly-x86_64-unknown-linux-gnu installed - (error reading rustc version)

info: default toolchain set to 'nightly-x86_64-unknown-linux-gnu'
info: checking for self-updates

$ cross build --target aarch64-unknown-linux-gnu                         
info: downloading component 'rust-std' for 'aarch64-unknown-linux-gnu'
info: installing component 'rust-std' for 'aarch64-unknown-linux-gnu'
info: using up to 500.0 MiB of RAM to unpack components
 26.6 MiB /  26.6 MiB (100 %)  11.5 MiB/s in  2s ETA:  0s
   Compiling libc v0.2.77
   Compiling proc-macro2 v1.0.21
   Compiling syn v1.0.41
...
```
</details>