### PR TITLE
fix image builds with update of dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,8 @@ jobs:
         i686-unknown-freebsd:            { TARGET: i686-unknown-freebsd,                    DYLIB: 1, STD: 1 }
         x86_64-unknown-freebsd:          { TARGET: x86_64-unknown-freebsd,                  DYLIB: 1, STD: 1 }
         x86_64-unknown-netbsd:           { TARGET: x86_64-unknown-netbsd,           CPP: 1, DYLIB: 1, STD: 1 }
-        sparcv9-sun-solaris:             { TARGET: sparcv9-sun-solaris,             CPP: 1, DYLIB: 1, STD: 1 }
-        x86_64-sun-solaris:              { TARGET: x86_64-sun-solaris,              CPP: 1, DYLIB: 1, STD: 1 }
+        # sparcv9-sun-solaris:             { TARGET: sparcv9-sun-solaris,             CPP: 1, DYLIB: 1, STD: 1 }
+        # x86_64-sun-solaris:              { TARGET: x86_64-sun-solaris,              CPP: 1, DYLIB: 1, STD: 1 }
         asmjs-unknown-emscripten:        { TARGET: asmjs-unknown-emscripten,                          STD: 1,                   RUN: 1 }
         # `cargo run` fails with an assertion error (https://github.com/rust-lang/cargo/issues/4689) on `wasm32-unknown-emscripten`.
         wasm32-unknown-emscripten:       { TARGET: wasm32-unknown-emscripten,                         STD: 1 }

--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 main() {
     local arch="${1}"
 
-    local sqlite_ver=3.33.0,1 \
-          openssl_ver=1.1.1i,1 \
+    local sqlite_ver=3.34.0,1 \
+          openssl_ver=1.1.1j,1 \
           target="${arch}-unknown-freebsd12"
 
     local td

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 main() {
     # arch in the rust target
     local arch="${1}" \
-          kversion=4.19.0-12
+          kversion=4.19.0-14
 
     local debsource="deb http://http.debian.net/debian/ buster main"
     debsource="${debsource}\ndeb http://security.debian.org/ buster/updates main"

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 main() {
     # arch in the rust target
     local arch="${1}" \
-          kversion=4.19.0-11
+          kversion=4.19.0-12
 
     local debsource="deb http://http.debian.net/debian/ buster main"
     debsource="${debsource}\ndeb http://security.debian.org/ buster/updates main"


### PR DESCRIPTION
Docker images fail to build in pipeline because linux image packages was updated in debian repo.

I updated to 4.19.0-14