### PR TITLE
Added environment variables to control the UID and GID in the container

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -151,7 +151,14 @@ pub fn run(target: &Target,
     // We need to specify the user for Docker, but not for Podman.
     if let Ok(ce) = get_container_engine() {
         if ce.ends_with(DOCKER) {
-            docker.args(&["--user", &format!("{}:{}", id::user(), id::group())]);
+            docker.args(&[
+                "--user",
+                &format!(
+                    "{}:{}",
+                    env::var("CROSS_CONTAINER_UID").unwrap_or(id::user().to_string()),
+                    env::var("CROSS_CONTAINER_GID").unwrap_or(id::group().to_string()),
+                ),
+            ]);
         }
     }
 


### PR DESCRIPTION
`CROSS_CONTAINER_UID` and `CROSS_CONTAINER_GID` can now be used to control the user and group ID's passed to Docker.

I ran into this when trying to setup a Github-Action that runs on MacOS and uses docker-machine which wasn't working. I then found https://github.com/rust-embedded/cross/issues/389 which described the solution of updating the UID and GID which I've confirmed works. This change should make it easier for users to solve for the same issue without making a fork.