### PR TITLE
Remove extra slash in project mount 

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -180,7 +180,7 @@ pub fn run(target: &Target,
         .args(&["-v", &format!("{}:/cargo:Z", cargo_dir.display())])
         // Prevent `bin` from being mounted inside the Docker container.
         .args(&["-v", "/cargo/bin"])
-        .args(&["-v", &format!("{}:/{}:Z", mount_root.display(), mount_root.display())])
+        .args(&["-v", &format!("{}:{}:Z", mount_root.display(), mount_root.display())])
         .args(&["-v", &format!("{}:/rust:Z,ro", sysroot.display())])
         .args(&["-v", &format!("{}:/target:Z", target_dir.display())])
         .args(&["-w", &mount_root.display().to_string()]);


### PR DESCRIPTION
Old code was adding extra slash
```
 "-v" "/Users/runner/work/my-rust-project://Users/runner/work/my-rust-project:Z"
```