### PR TITLE
Remove explicit semver dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,6 @@ dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-escape 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ home = "0.5"
 lazy_static = "1.0"
 libc = "0.2.18"
 rustc_version = "0.2"
-semver = "0.9"
 toml = "0.5"
 which = { version = "3.1.0", default_features = false }
 shell-escape = "0.1.4"


### PR DESCRIPTION
This crate only uses semver transitively through the rustc_version crate. It does not need to directly depend on semver.