### PR TITLE
Do no panic when passed empty string as argument. closes #466

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub fn parse(target_list: &TargetList) -> Args {
     {
         let mut args = env::args().skip(1);
         while let Some(arg) = args.next() {
-            if arg.len() == 0 {
+            if arg.is_empty() {
                 continue;
             }
             if let ("+", ch) = arg.split_at(1) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,9 @@ pub fn parse(target_list: &TargetList) -> Args {
     {
         let mut args = env::args().skip(1);
         while let Some(arg) = args.next() {
+            if arg.len() == 0 {
+                continue;
+            }
             if let ("+", ch) = arg.split_at(1) {
                 channel = Some(ch.to_string());
             } else if arg == "--target" {


### PR DESCRIPTION
When parsing argument `parse()` function in `src/cli.rs`  splits the argument string without checking length which results in panic when splitting empty string.
This PR pix that issue by introducing `continue` on empty string.