### PR TITLE
Update Android NDK version and API version

### DIFF
--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm64 21
+RUN /android-ndk.sh arm64 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm 21
+RUN /android-ndk.sh arm 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm 21
+RUN /android-ndk.sh arm 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh x86 21
+RUN /android-ndk.sh x86 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh x86_64 21
+RUN /android-ndk.sh x86_64 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /

--- a/docker/android-ndk.sh
+++ b/docker/android-ndk.sh
@@ -3,7 +3,7 @@
 set -x
 set -euo pipefail
 
-NDK_URL=https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+NDK_URL=https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
 
 main() {
     local arch="${1}" \


### PR DESCRIPTION
This PR updates Android NDK version and API version as the same as libc crate.

https://github.com/rust-lang/libc/blob/master/ci/android-install-ndk.sh

Fix https://github.com/rust-embedded/cross/issues/195